### PR TITLE
Honour switchWaitDuration, also refactor switch focus logic

### DIFF
--- a/src/skippy.h
+++ b/src/skippy.h
@@ -181,12 +181,6 @@ typedef enum {
 	CLIDISP_THUMBNAIL_ICON,
 } client_disp_mode_t;
 
-typedef enum {
-	FI_PREV = -1,
-	FI_CURR =  0,
-	FI_NEXT = +1,
-} focus_initial;
-
 /// @brief Option structure.
 typedef struct {
 	char *config_path;


### PR DESCRIPTION
closes #25 

Originally I thought to code the switch feature so that during switchWaitDuration, the user can cycle through the windows without the window previews showing. However I changed my mind, and the user can only switch between current and next/prev window during switchWaitDuration. The reason is because cycling through windows require major refactoring around relevant code paths, as well as maneuver around the windows z-order list, which is susceptible to potential race condition (when windows are created/destroyed/switched with other apps). Not worth all these complications in my opinion.