### PR TITLE
Fix broken default for fillSpec

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1835,7 +1835,7 @@ load_config_file(session_t *ps)
     }
 	{
 		char defaultstr[256] = "orig mid mid ";
-		const char* sspec = config_get(config, "display", "fillSpec", "mid mid #333333");
+		const char* sspec = config_get(config, "display", "fillSpec", "#333333");
 		strcat(defaultstr, sspec);
 		if (!parse_pictspec(ps, defaultstr, &ps->o.fillSpec))
 			return RET_BADARG;


### PR DESCRIPTION
Fixes skippy crashing if it doesn't find a default fillSpec value in the user config, the default string looked like `orig mid mid mid mid #333333`, causing all the parsing functions to get confused.