### PR TITLE
Stupid attempt at non-EWMH virtual desktop paging

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -523,6 +523,9 @@ static bool
 init_paging_layout(MainWin *mw, enum layoutmode layout, Window leader)
 {
 	int screencount = wm_get_desktops(mw->ps);
+#ifdef CFG_XINERAMA
+	screencount /= mw->xin_screens;
+#endif
 	if (screencount == -1)
 		screencount = 1;
 	int desktop_dim = ceil(sqrt(screencount));


### PR DESCRIPTION
_NET_NUMBER_OF_DESKTOPS in awesome and i3 seems not to be following EWMH, and are proportionate to the number of physical screens, as opposed to XFCE, openbox, xmonad with EWMH virtual desktop plugin, where _NET_NUMBER_OF_DESKTOPS is a fixed number of virtual desktops, regardless of the number of physical screens available.

This PR is kind of a stupid attempt to fix that. If testing show that it works, then config option will be added for user to toggle behaviour.