### PR TITLE
For boxy expose, stabilize window layout when z-order changes,

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -498,8 +498,10 @@ static bool
 init_layout(MainWin *mw, enum layoutmode layout, Window leader)
 {
 	unsigned int newwidth = 100, newheight = 100;
-	if (mw->clientondesktop)
+	if (mw->clientondesktop) {
+		dlist_sort(mw->clientondesktop, sort_cw_by_id, 0);
 		layout_run(mw, mw->clientondesktop, &newwidth, &newheight, layout);
+	}
 
 	float multiplier = (float) (mw->width - 2 * mw->distance) / newwidth;
 	if (multiplier * newheight > mw->height - 2 * mw->distance)

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -1347,6 +1347,20 @@ sort_cw_by_column(dlist* dlist1, dlist* dlist2, void* data)
 		return 0;
 }
 
+static inline int
+sort_cw_by_id(dlist* dlist1, dlist* dlist2, void* data)
+{
+	ClientWin *cw1 = (ClientWin *) dlist1->data;
+	ClientWin *cw2 = (ClientWin *) dlist2->data;
+
+	if (cw1->src.window < cw2->src.window)
+		return -1;
+	else if (cw1->src.window > cw2->src.window)
+		return 1;
+	else
+		return 0;
+}
+
 extern session_t *ps_g;
 
 int load_config_file(session_t *ps);


### PR DESCRIPTION
by first sorting by window id