### PR TITLE
For boxy expose, stabilize window layout when z-order changes

### DIFF
--- a/src/layout.c
+++ b/src/layout.c
@@ -41,8 +41,12 @@ void layout_run(MainWin *mw, dlist *windows,
 		unsigned int *total_width, unsigned int *total_height,
 		enum layoutmode layout) {
 	if (layout == LAYOUTMODE_EXPOSE
-			&& mw->ps->o.exposeLayout == LAYOUT_BOXY)
-		layout_boxy(mw, windows, total_width, total_height);
+			&& mw->ps->o.exposeLayout == LAYOUT_BOXY) {
+		dlist *sorted_windows = dlist_dup(windows);
+		dlist_sort(sorted_windows, sort_cw_by_id, 0);
+		layout_boxy(mw, sorted_windows, total_width, total_height);
+		dlist_free(sorted_windows);
+	}
 	else {
 		// to get the proper z-order based window ordering,
 		// reversing the list of windows is needed

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -1347,6 +1347,20 @@ sort_cw_by_column(dlist* dlist1, dlist* dlist2, void* data)
 		return 0;
 }
 
+static inline int
+sort_cw_by_id(dlist* dlist1, dlist* dlist2, void* data)
+{
+	ClientWin *cw1 = (ClientWin *) dlist1->data;
+	ClientWin *cw2 = (ClientWin *) dlist2->data;
+
+	if (cw1->src.window < cw2->src.window)
+		return -1;
+	else if (cw1->src.window > cw2->src.window)
+		return 1;
+	else
+		return 0;
+}
+
 extern session_t *ps_g;
 
 int load_config_file(session_t *ps);


### PR DESCRIPTION
Achieved by sorting window list before layout_boxy()