### PR TITLE
Reload config option tooltip/show no longer segfaults

### DIFF
--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -13,6 +13,11 @@
 # opacity is an integer in the range of 0-255
 #
 
+# for system config options, stop and then start new skippy daemon
+# to reload config options
+# all other config options can be reloaded on the fly
+# with skippy-xd --config-reload
+
 [system]
 
 # File path of skippy-xd pipe daemon communication

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -105,12 +105,6 @@ clientwin_create(MainWin *mw, Window client) {
 	cw->pixmap = None;
 	cw->cpixmap = None;
 
-	if (ps->o.tooltip_show) {
-		if (cw->tooltip)
-			tooltip_destroy(cw->tooltip);
-		cw->tooltip = tooltip_create(mw);
-	}
-
 	if (ps->o.includeFrame)
 		cw->src.window = wm_find_frame(ps, client);
 	if (!cw->src.window)
@@ -216,6 +210,12 @@ clientwin_update(ClientWin *cw) {
 		cw->src.width = wattr.width;
 		cw->src.height = wattr.height;
 		cw->src.format = XRenderFindVisualFormat(ps->dpy, wattr.visual);
+	}
+
+	if (ps->o.tooltip_show) {
+		if (cw->tooltip)
+			tooltip_destroy(cw->tooltip);
+		cw->tooltip = tooltip_create(cw->mainwin);
 	}
 
 	bool isViewable = wattr.map_state == IsViewable;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -780,6 +780,12 @@ init_paging_layout(MainWin *mw, enum layoutmode layout, Window leader)
 
 			clientwin_move(cw, mw->multiplier, mw->xoff, mw->yoff, 1);
 
+			if (mw->ps->o.tooltip_show) {
+				if (cw->tooltip)
+					tooltip_destroy(cw->tooltip);
+				cw->tooltip = tooltip_create(cw->mainwin);
+			}
+
 			if (!mw->dminis)
 				mw->dminis = dlist_add(NULL, cw);
 			else

--- a/src/tooltip.c
+++ b/src/tooltip.c
@@ -235,7 +235,7 @@ tooltip_unmap(Tooltip *tt)
 void
 tooltip_handle(Tooltip *tt)
 {
-	if (!tt->text)
+	if (!tt || !tt->text)
 		return;
 	
 	XftDrawRect(tt->draw, &tt->border, 0, 0, tt->width, 1);


### PR DESCRIPTION
It used to segfault specifically when tooltip/show was false, then set to true via `--config-reload`