### PR TITLE
Fix segfault when long pressing window close

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -731,6 +731,11 @@ close_clientwindow(ClientWin* cw, enum cliop op) {
 	MainWin *mw = cw->mainwin;
 	session_t *ps = mw->ps;
 
+	if (cw == mw->client_to_focus)
+		mw->client_to_focus = NULL;
+	if (cw == mw->client_to_focus_on_cancel)
+		mw->client_to_focus_on_cancel = NULL;
+
 	clientwin_unmap(cw);
 	clientwin_action(cw, op);
 	XFlush(ps->dpy);

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -494,6 +494,9 @@ mainwin_handle(MainWin *mw, XEvent *ev) {
 	printfdf(false, "(): ");
 	session_t *ps = mw->ps;
 
+	if (!mw->clientondesktop)
+		return 1;
+
 	switch(ev->type) {
 		case EnterNotify:
 			if (!mw->client_to_focus)

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1276,8 +1276,11 @@ mainloop(session_t *ps, bool activate_on_start) {
 					//((ClientWin *)iter->data)->damaged = true;
 				//}
 			}
-			else if (mw && wid == mw->window)
+			else if (mw && wid == mw->window) {
 				die = mainwin_handle(mw, &ev);
+				if (die)
+					mw->client_to_focus = NULL;
+			}
 			else if (mw && PropertyNotify == ev.type) {
 				printfdf(false, "(): else if (ev.type == PropertyNotify) {");
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1276,11 +1276,8 @@ mainloop(session_t *ps, bool activate_on_start) {
 					//((ClientWin *)iter->data)->damaged = true;
 				//}
 			}
-			else if (mw && wid == mw->window) {
+			else if (mw && wid == mw->window)
 				die = mainwin_handle(mw, &ev);
-				if (die)
-					mw->client_to_focus = NULL;
-			}
 			else if (mw && PropertyNotify == ev.type) {
 				printfdf(false, "(): else if (ev.type == PropertyNotify) {");
 


### PR DESCRIPTION
close #98 

The X events are processed in a non-deterministic series:

In typical sequence, clientwin_handle() is called in
https://github.com/felixfung/skippy-xd/blob/592b26bebafe992517f630f6a2b441fdc889f8f3/src/skippy.c#L1309 which deletes the client window object; then `mw->client_to_focus = NULL` is reset in https://github.com/felixfung/skippy-xd/blob/592b26bebafe992517f630f6a2b441fdc889f8f3/src/skippy.c#L1245 and https://github.com/felixfung/skippy-xd/blob/592b26bebafe992517f630f6a2b441fdc889f8f3/src/skippy.c#L1280 is called, which short circuits on `mw->client_to_focus == NULL`

Sometimes, `mw->client_to_focus = NULL` from https://github.com/felixfung/skippy-xd/blob/592b26bebafe992517f630f6a2b441fdc889f8f3/src/skippy.c#L1245
is NOT called. Then we get dereferencing of the stale pointer of the deleted client window object in https://github.com/felixfung/skippy-xd/blob/592b26bebafe992517f630f6a2b441fdc889f8f3/src/mainwin.c#L508

Hence, mainwin_handle() has to check for the same condition as https://github.com/felixfung/skippy-xd/blob/592b26bebafe992517f630f6a2b441fdc889f8f3/src/skippy.c#L1245 which is `if (!mw->clientondesktop)`