### PR TITLE
Allow activation when no windows present

### DIFF
--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -494,11 +494,6 @@ mainwin_handle(MainWin *mw, XEvent *ev) {
 	printfdf(false, "(): ");
 	session_t *ps = mw->ps;
 
-	if (!mw->clientondesktop) {
-		printfdf(false, "(): No client windows to display");
-		return 1;
-	}
-
 	switch(ev->type) {
 		case EnterNotify:
 			printfdf(false, "(): EnterNotify");


### PR DESCRIPTION
The root cause fix for #99 should be to set
```
mw->client_to_focus = NULL;
```