### PR TITLE
panel/allowClick config option

### DIFF
--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -131,6 +131,7 @@ show = true
 showDesktop = false
 backgroundTinting = true
 allowOverlap = true
+allowClick = false
 
 [tooltip]
 show = true

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -876,6 +876,7 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 							ps->o.bindings_miwMouse[button]);
 				}
 			}
+			cw->mainwin->pressed_mouse = false;
 		}
 		else
 			printfdf(false, "(): ButtonRelease %u ignored.", button);

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -560,6 +560,7 @@ mainwin_handle(MainWin *mw, XEvent *ev) {
 						return 0;
 					}
 				}
+				mw->pressed_mouse = false;
 				printfdf(false, "(): Detected mouse button release on main window, "
 						"exiting.");
 				return 1;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1318,21 +1318,36 @@ mainloop(session_t *ps, bool activate_on_start) {
 					ClientWin *cw = (ClientWin *) iter->data;
 					if (cw->mini.window == wid) {
 						if (ps->o.panel_allow_click) {
-							if (ev.type == ButtonPress)
-								cw->mainwin->pressed_mouse = true;
-							if (ev.type == ButtonRelease
-								&& cw->mainwin->pressed_mouse) {
-									printfdf(true,
-											"(): panel click redirection %#010x -> %#010x (%d,%d)",
-											ev.xbutton.window,
-											cw->wid_client,
-											ev.xbutton.x, ev.xbutton.y);
+							if (ev.type == ButtonPress) {
+								printfdf(true,
+										"(): panel button (%d) redirection %#010x -> %#010x (%d,%d)",
+										ev.xbutton.button,
+										ev.xbutton.window,
+										cw->wid_client,
+										ev.xbutton.x, ev.xbutton.y);
+								ev.xbutton.window = cw->wid_client;
 
-									ev.xbutton.window = cw->wid_client;
-									XSendEvent(ps->dpy, cw->wid_client,
-											False, ButtonReleaseMask, &ev);
-									XFlush(ps->dpy);
-									cw->mainwin->pressed_mouse = false;
+								XSendEvent(ps->dpy, cw->wid_client,
+										True, ButtonReleaseMask, &ev);
+
+								XFlush(ps->dpy);
+								cw->mainwin->pressed_mouse = true;
+							}
+							else if (ev.type == ButtonRelease
+							&& cw->mainwin->pressed_mouse) {
+								printfdf(true,
+										"(): button release (%d) redirection %#010x -> %#010x (%d,%d)",
+										ev.xbutton.button,
+										ev.xbutton.window,
+										cw->wid_client,
+										ev.xbutton.x, ev.xbutton.y);
+								ev.xbutton.window = cw->wid_client;
+
+								XSendEvent(ps->dpy, cw->wid_client,
+										True, ButtonReleaseMask, &ev);
+
+								XFlush(ps->dpy);
+								cw->mainwin->pressed_mouse = false;
 							}
 						}
 						else {

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -38,6 +38,7 @@
 #include <X11/Xmd.h>
 #include <X11/Xatom.h>
 #include <X11/Xft/Xft.h>
+#include <X11/Xutil.h>
 
 #include <X11/extensions/Xrender.h>
 #include <X11/extensions/Xcomposite.h>

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -232,6 +232,7 @@ typedef struct {
 	bool panel_show_desktop;
 	bool panel_tinting;
 	bool panel_allow_overlap;
+	bool panel_allow_click;
 
 	bool tooltip_show;
 	bool tooltip_showDesktop;
@@ -306,6 +307,7 @@ typedef struct {
 	.panel_show_desktop = false, \
 	.panel_tinting = true, \
 	.panel_allow_overlap = true, \
+	.panel_allow_click = false, \
 	.tooltip_show = true, \
 	.tooltip_showDesktop = true, \
 	.tooltip_showMonitor = true, \


### PR DESCRIPTION
closing #124 

For mysterious reason, this is not working. Internet research says `XSendEvent()` is kinda hard to use...

An alternative is to use `XTestFakeMotionEvent()` rather than `XSendEvent()`, but that would require new library dependency `libxtst`.