### PR TITLE
Pivot key can be single activate key to skippy-xd while holding it

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1412,7 +1412,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 					else if (mw && ps->o.focus_initial == 0) {
 						printfdf(false, "(): toggling skippy off");
 
-						KeyCode *pivotkey = NULL; // mw->keycodes_PivotExpose;
+						KeyCode *pivotkey = NULL;
 						if (layout == LAYOUTMODE_SWITCH)
 							pivotkey = mw->keycodes_PivotSwitch;
 						else if (layout == LAYOUTMODE_EXPOSE)

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1389,6 +1389,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 					if (!mw || !mw->mapped)
 					{
+						printfdf(false, "(): skippy activating, mode=%d", layout);
 						animating = activate = true;
 						if ((piped_input | PIPECMD_PREV | PIPECMD_NEXT)
 								== (PIPECMD_SWITCH | PIPECMD_PREV | PIPECMD_NEXT)) {
@@ -1405,13 +1406,25 @@ mainloop(session_t *ps, bool activate_on_start) {
 							ps->o.mode = PROGMODE_PAGING;
 							layout = LAYOUTMODE_PAGING;
 						}
-						printfdf(false, "(): skippy activating, mode=%d", layout);
 					}
+					// parameter == 0, toggle
+					// otherwise shift window focus
 					else if (mw && ps->o.focus_initial == 0) {
-						// parameter == 0, toggle
-						// otherwise shift window focus
-						mw->refocus = die = true;
 						printfdf(false, "(): toggling skippy off");
+
+						KeyCode *pivotkey = NULL; // mw->keycodes_PivotExpose;
+						if (layout == LAYOUTMODE_SWITCH)
+							pivotkey = mw->keycodes_PivotSwitch;
+						else if (layout == LAYOUTMODE_EXPOSE)
+							pivotkey = mw->keycodes_PivotExpose;
+						else if (layout == LAYOUTMODE_PAGING)
+							pivotkey = mw->keycodes_PivotPaging;
+
+						if (!pivotkey)
+							mw->refocus = die = true;
+						else if (pivotkey && !pivoting(ps, pivotkey))
+							die = true;
+
 						break;
 					}
 					else if (mw && mw->mapped)


### PR DESCRIPTION
E.g. hold Super to trigger expose, and when Super is released, expose deactivates. In essence it is Alt-Tab without the Tab, using up/down/left/right/prev/next and mouse to navigate.