### PR TITLE
Redesigning Pivot Logic and Cmdline Parameters

### DIFF
--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -152,12 +152,22 @@ font = fixed-11:weight=bold
 
 [hotkeys]
 
-# The "pivot" keys are the Alt in Alt-Tab
-# The key has to be held for skippy-xd to activate
-# And when the key is released, skippy-xd selects the highlighted window.
-# If there are no entries to the pivot key,
-# The behaviour is to toggle skippy-xd activation
-# And no keys need to be held or released
+# This section set up hot keys for pivot mode
+# When both the pivot and tap keys are set
+# Then holding the pivot key while tapping the tap key
+# Would trigger pivot mode and highlight the next window
+# Releasing the pivot key would select the highlighted window
+# When only the pivot key is set
+# Then holding the pivot key would trigger pivot mode
+# Releasing the pivot key would select the highlighted window
+
+# Pivot mode is independent of toggling mode
+# Which is triggered/toggled through command line interface
+# `skippy-xd --expose`
+# `skippy-xd --paging`
+# And no pivot keys need to be held
+# So that you can have different set ups for pivot and toggling
+
 switchPivot = Alt_L
 switchTap = Tab
 exposePivot = 

--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -177,8 +177,8 @@ keysRight = Right
 
 keysSelect = Return space
 keysCancel = Escape
-keysNext = n
-keysPrev = p
+keysNext = Tab
+keysReverse = ShiftMask
 
 keysIconify = 1
 keysShade = 2

--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -150,6 +150,21 @@ text = #ffffff
 textShadow = black
 font = fixed-11:weight=bold
 
+[hotkeys]
+
+# The "pivot" keys are the Alt in Alt-Tab
+# The key has to be held for skippy-xd to activate
+# And when the key is released, skippy-xd selects the highlighted window.
+# If there are no entries to the pivot key,
+# The behaviour is to toggle skippy-xd activation
+# And no keys need to be held or released
+switchPivot = Alt_L
+switchTap = Tab
+exposePivot = 
+exposeTap = 
+pagingPivot = 
+pagingTap = 
+
 [bindings]
 
 # key* = is a list of valid XWindows KeySym identifiers, case
@@ -185,13 +200,3 @@ miwMouse2 = close-ewmh
 miwMouse3 = iconify
 miwMouse4 = keysNext
 miwMouse5 = keysPrev
-
-# The "pivot" keys are the Alt in Alt-Tab
-# The key has to be held for skippy-xd to activate
-# And when the key is released, skippy-xd selects the highlighted window.
-# If there are no entries to the pivot key,
-# The behaviour is to toggle skippy-xd activation
-# And no keys need to be held or released
-keysPivotSwitch = Alt_L
-keysPivotExpose = 
-keysPivotPaging = 

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -823,10 +823,12 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 			focus_left(cw->mainwin->client_to_focus);
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_Right, evk->keycode))
 			focus_right(cw->mainwin->client_to_focus);
-		else if (arr_keycodes_includes(cw->mainwin->keycodes_Prev, evk->keycode))
-			focus_miniw_prev(ps, cw->mainwin->client_to_focus);
-		else if (arr_keycodes_includes(cw->mainwin->keycodes_Next, evk->keycode))
-			focus_miniw_next(ps, cw->mainwin->client_to_focus);
+		else if (arr_keycodes_includes(cw->mainwin->keycodes_Next, evk->keycode)) {
+			if (arr_modkeymasks_includes(cw->mainwin->keymasks_Reverse, evk->state))
+				focus_miniw_prev(ps, cw->mainwin->client_to_focus);
+			else
+				focus_miniw_next(ps, cw->mainwin->client_to_focus);
+		}
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_Cancel, evk->keycode))
 		{
 			mw->refocus = true;

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -142,8 +142,11 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keys_str_syms(ps->o.bindings_keysShade, &mw->keysyms_Shade);
 	keys_str_syms(ps->o.bindings_keysClose, &mw->keysyms_Close);
 	keys_str_syms(ps->o.bindings_keysPivotSwitch, &mw->keysyms_PivotSwitch);
+	keys_str_syms(ps->o.bindings_keysTapSwitch, &mw->keysyms_TapSwitch);
 	keys_str_syms(ps->o.bindings_keysPivotExpose, &mw->keysyms_PivotExpose);
+	keys_str_syms(ps->o.bindings_keysTapExpose, &mw->keysyms_TapExpose);
 	keys_str_syms(ps->o.bindings_keysPivotPaging, &mw->keysyms_PivotPaging);
+	keys_str_syms(ps->o.bindings_keysTapPaging, &mw->keysyms_TapPaging);
 
 	// convert the arrays of KeySyms into arrays of KeyCodes, for this specific Display
 	keysyms_arr_keycodes(dpy, mw->keysyms_Up, &mw->keycodes_Up);
@@ -158,8 +161,11 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keysyms_arr_keycodes(dpy, mw->keysyms_Shade, &mw->keycodes_Shade);
 	keysyms_arr_keycodes(dpy, mw->keysyms_Close, &mw->keycodes_Close);
 	keysyms_arr_keycodes(dpy, mw->keysyms_PivotSwitch, &mw->keycodes_PivotSwitch);
+	keysyms_arr_keycodes(dpy, mw->keysyms_TapSwitch, &mw->keycodes_TapSwitch);
 	keysyms_arr_keycodes(dpy, mw->keysyms_PivotExpose, &mw->keycodes_PivotExpose);
+	keysyms_arr_keycodes(dpy, mw->keysyms_TapExpose, &mw->keycodes_TapExpose);
 	keysyms_arr_keycodes(dpy, mw->keysyms_PivotPaging, &mw->keycodes_PivotPaging);
+	keysyms_arr_keycodes(dpy, mw->keysyms_TapPaging, &mw->keycodes_TapPaging);
 
 	// we check all possible pairs, one pair at a time. This is in a specific order, to give a more helpful error msg
 	check_keybindings_conflict(ps->o.config_path, "keysUp", mw->keysyms_Up, "keysDown", mw->keysyms_Down);
@@ -475,8 +481,11 @@ mainwin_destroy(MainWin *mw) {
 	free(mw->keysyms_Shade);
 	free(mw->keysyms_Close);
 	free(mw->keysyms_PivotSwitch);
+	free(mw->keysyms_TapSwitch);
 	free(mw->keysyms_PivotExpose);
+	free(mw->keysyms_TapExpose);
 	free(mw->keysyms_PivotPaging);
+	free(mw->keysyms_TapPaging);
 
 	free(mw->keycodes_Up);
 	free(mw->keycodes_Down);
@@ -490,8 +499,11 @@ mainwin_destroy(MainWin *mw) {
 	free(mw->keycodes_Shade);
 	free(mw->keycodes_Close);
 	free(mw->keycodes_PivotSwitch);
+	free(mw->keycodes_TapSwitch);
 	free(mw->keycodes_PivotExpose);
+	free(mw->keycodes_TapExpose);
 	free(mw->keycodes_PivotPaging);
+	free(mw->keycodes_TapPaging);
 
 	free(mw);
 }

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -134,7 +134,6 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keys_str_syms(ps->o.bindings_keysDown, &mw->keysyms_Down);
 	keys_str_syms(ps->o.bindings_keysLeft, &mw->keysyms_Left);
 	keys_str_syms(ps->o.bindings_keysRight, &mw->keysyms_Right);
-	keys_str_syms(ps->o.bindings_keysPrev, &mw->keysyms_Prev);
 	keys_str_syms(ps->o.bindings_keysNext, &mw->keysyms_Next);
 	keys_str_syms(ps->o.bindings_keysCancel, &mw->keysyms_Cancel);
 	keys_str_syms(ps->o.bindings_keysSelect, &mw->keysyms_Select);
@@ -153,7 +152,6 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keysyms_arr_keycodes(dpy, mw->keysyms_Down, &mw->keycodes_Down);
 	keysyms_arr_keycodes(dpy, mw->keysyms_Left, &mw->keycodes_Left);
 	keysyms_arr_keycodes(dpy, mw->keysyms_Right, &mw->keycodes_Right);
-	keysyms_arr_keycodes(dpy, mw->keysyms_Prev, &mw->keycodes_Prev);
 	keysyms_arr_keycodes(dpy, mw->keysyms_Next, &mw->keycodes_Next);
 	keysyms_arr_keycodes(dpy, mw->keysyms_Cancel, &mw->keycodes_Cancel);
 	keysyms_arr_keycodes(dpy, mw->keysyms_Select, &mw->keycodes_Select);
@@ -166,6 +164,8 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keysyms_arr_keycodes(dpy, mw->keysyms_TapExpose, &mw->keycodes_TapExpose);
 	keysyms_arr_keycodes(dpy, mw->keysyms_PivotPaging, &mw->keycodes_PivotPaging);
 	keysyms_arr_keycodes(dpy, mw->keysyms_TapPaging, &mw->keycodes_TapPaging);
+
+	modkeymasks_str_enums(ps->o.bindings_masksReverse, &mw->keymasks_Reverse);
 
 	// we check all possible pairs, one pair at a time. This is in a specific order, to give a more helpful error msg
 	check_keybindings_conflict(ps->o.config_path, "keysUp", mw->keysyms_Up, "keysDown", mw->keysyms_Down);
@@ -183,11 +183,6 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	check_keybindings_conflict(ps->o.config_path, "keysLeft", mw->keysyms_Left, "keysCancel", mw->keysyms_Cancel);
 	check_keybindings_conflict(ps->o.config_path, "keysLeft", mw->keysyms_Left, "keysSelect", mw->keysyms_Select);
 	//check_keybindings_conflict(ps->o.config_path, "keysLeft", mw->keysyms_Left, "keysPivot", mw->keysyms_Pivot);
-	check_keybindings_conflict(ps->o.config_path, "keysRight", mw->keysyms_Prev, "keysCancel", mw->keysyms_Cancel);
-	check_keybindings_conflict(ps->o.config_path, "keysRight", mw->keysyms_Prev, "keysSelect", mw->keysyms_Select);
-	//check_keybindings_conflict(ps->o.config_path, "keysRight", mw->keysyms_Prev, "keysPivot", mw->keysyms_Pivot);
-	check_keybindings_conflict(ps->o.config_path, "keysPrev", mw->keysyms_Prev, "keysCancel", mw->keysyms_Cancel);
-	check_keybindings_conflict(ps->o.config_path, "keysPrev", mw->keysyms_Prev, "keysSelect", mw->keysyms_Select);
 	check_keybindings_conflict(ps->o.config_path, "keysNext", mw->keysyms_Next, "keysCancel", mw->keysyms_Cancel);
 	check_keybindings_conflict(ps->o.config_path, "keysNext", mw->keysyms_Next, "keysSelect", mw->keysyms_Select);
 	check_keybindings_conflict(ps->o.config_path, "keysCancel", mw->keysyms_Cancel, "keysSelect", mw->keysyms_Select);
@@ -473,7 +468,6 @@ mainwin_destroy(MainWin *mw) {
 	free(mw->keysyms_Down);
 	free(mw->keysyms_Left);
 	free(mw->keysyms_Right);
-	free(mw->keysyms_Prev);
 	free(mw->keysyms_Next);
 	free(mw->keysyms_Cancel);
 	free(mw->keysyms_Select);
@@ -491,7 +485,6 @@ mainwin_destroy(MainWin *mw) {
 	free(mw->keycodes_Down);
 	free(mw->keycodes_Left);
 	free(mw->keycodes_Right);
-	free(mw->keycodes_Prev);
 	free(mw->keycodes_Next);
 	free(mw->keycodes_Cancel);
 	free(mw->keycodes_Select);
@@ -504,6 +497,8 @@ mainwin_destroy(MainWin *mw) {
 	free(mw->keycodes_TapExpose);
 	free(mw->keycodes_PivotPaging);
 	free(mw->keycodes_TapPaging);
+
+	free(mw->keymasks_Reverse);
 
 	free(mw);
 }

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -171,6 +171,10 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 			int grabkey_status =
 					XGrabKey(ps->dpy, keycode, AnyModifier,
 							DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
+			if (grabkey_status != 1) {
+				printfef(true, "(): grabbing pivot key %s failed",
+						mw->ps->o.bindings_keysPivotSwitch);
+			}
 		}
 	}
 
@@ -180,6 +184,10 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 			int grabkey_status =
 					XGrabKey(ps->dpy, keycode, AnyModifier,
 							DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
+			if (grabkey_status != 1) {
+				printfef(true, "(): grabbing pivot key %s failed",
+						mw->ps->o.bindings_keysPivotExpose);
+			}
 		}
 	}
 
@@ -189,6 +197,10 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 			int grabkey_status =
 					XGrabKey(ps->dpy, keycode, AnyModifier,
 							DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
+			if (grabkey_status != 1) {
+				printfef(true, "(): grabbing pivot key %s failed",
+						mw->ps->o.bindings_keysPivotPaging);
+			}
 		}
 	}
 

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -125,45 +125,9 @@ mainwin_create_err:
 	return NULL;
 }
 
-MainWin *
-mainwin_reload(session_t *ps, MainWin *mw) {
+void
+mainwin_grab_pivot_keys(session_t *ps, MainWin *mw) {
 	Display * const dpy = ps->dpy;
-
-	// convert the keybindings settings strings into arrays of KeySyms
-	keys_str_syms(ps->o.bindings_keysUp, &mw->keysyms_Up);
-	keys_str_syms(ps->o.bindings_keysDown, &mw->keysyms_Down);
-	keys_str_syms(ps->o.bindings_keysLeft, &mw->keysyms_Left);
-	keys_str_syms(ps->o.bindings_keysRight, &mw->keysyms_Right);
-	keys_str_syms(ps->o.bindings_keysNext, &mw->keysyms_Next);
-	keys_str_syms(ps->o.bindings_keysCancel, &mw->keysyms_Cancel);
-	keys_str_syms(ps->o.bindings_keysSelect, &mw->keysyms_Select);
-	keys_str_syms(ps->o.bindings_keysIconify, &mw->keysyms_Iconify);
-	keys_str_syms(ps->o.bindings_keysShade, &mw->keysyms_Shade);
-	keys_str_syms(ps->o.bindings_keysClose, &mw->keysyms_Close);
-	keys_str_syms(ps->o.bindings_keysPivotSwitch, &mw->keysyms_PivotSwitch);
-	keys_str_syms(ps->o.bindings_keysTapSwitch, &mw->keysyms_TapSwitch);
-	keys_str_syms(ps->o.bindings_keysPivotExpose, &mw->keysyms_PivotExpose);
-	keys_str_syms(ps->o.bindings_keysTapExpose, &mw->keysyms_TapExpose);
-	keys_str_syms(ps->o.bindings_keysPivotPaging, &mw->keysyms_PivotPaging);
-	keys_str_syms(ps->o.bindings_keysTapPaging, &mw->keysyms_TapPaging);
-
-	// convert the arrays of KeySyms into arrays of KeyCodes, for this specific Display
-	keysyms_arr_keycodes(dpy, mw->keysyms_Up, &mw->keycodes_Up);
-	keysyms_arr_keycodes(dpy, mw->keysyms_Down, &mw->keycodes_Down);
-	keysyms_arr_keycodes(dpy, mw->keysyms_Left, &mw->keycodes_Left);
-	keysyms_arr_keycodes(dpy, mw->keysyms_Right, &mw->keycodes_Right);
-	keysyms_arr_keycodes(dpy, mw->keysyms_Next, &mw->keycodes_Next);
-	keysyms_arr_keycodes(dpy, mw->keysyms_Cancel, &mw->keycodes_Cancel);
-	keysyms_arr_keycodes(dpy, mw->keysyms_Select, &mw->keycodes_Select);
-	keysyms_arr_keycodes(dpy, mw->keysyms_Iconify, &mw->keycodes_Iconify);
-	keysyms_arr_keycodes(dpy, mw->keysyms_Shade, &mw->keycodes_Shade);
-	keysyms_arr_keycodes(dpy, mw->keysyms_Close, &mw->keycodes_Close);
-	keysyms_arr_keycodes(dpy, mw->keysyms_PivotSwitch, &mw->keycodes_PivotSwitch);
-	keysyms_arr_keycodes(dpy, mw->keysyms_TapSwitch, &mw->keycodes_TapSwitch);
-	keysyms_arr_keycodes(dpy, mw->keysyms_PivotExpose, &mw->keycodes_PivotExpose);
-	keysyms_arr_keycodes(dpy, mw->keysyms_TapExpose, &mw->keycodes_TapExpose);
-	keysyms_arr_keycodes(dpy, mw->keysyms_PivotPaging, &mw->keycodes_PivotPaging);
-	keysyms_arr_keycodes(dpy, mw->keysyms_TapPaging, &mw->keycodes_TapPaging);
 
 	XUngrabKey(ps->dpy, AnyKey, AnyModifier, DefaultRootWindow(dpy));
 
@@ -205,6 +169,49 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 			}
 		}
 	}
+}
+
+MainWin *
+mainwin_reload(session_t *ps, MainWin *mw) {
+	Display * const dpy = ps->dpy;
+
+	// convert the keybindings settings strings into arrays of KeySyms
+	keys_str_syms(ps->o.bindings_keysUp, &mw->keysyms_Up);
+	keys_str_syms(ps->o.bindings_keysDown, &mw->keysyms_Down);
+	keys_str_syms(ps->o.bindings_keysLeft, &mw->keysyms_Left);
+	keys_str_syms(ps->o.bindings_keysRight, &mw->keysyms_Right);
+	keys_str_syms(ps->o.bindings_keysNext, &mw->keysyms_Next);
+	keys_str_syms(ps->o.bindings_keysCancel, &mw->keysyms_Cancel);
+	keys_str_syms(ps->o.bindings_keysSelect, &mw->keysyms_Select);
+	keys_str_syms(ps->o.bindings_keysIconify, &mw->keysyms_Iconify);
+	keys_str_syms(ps->o.bindings_keysShade, &mw->keysyms_Shade);
+	keys_str_syms(ps->o.bindings_keysClose, &mw->keysyms_Close);
+	keys_str_syms(ps->o.bindings_keysPivotSwitch, &mw->keysyms_PivotSwitch);
+	keys_str_syms(ps->o.bindings_keysTapSwitch, &mw->keysyms_TapSwitch);
+	keys_str_syms(ps->o.bindings_keysPivotExpose, &mw->keysyms_PivotExpose);
+	keys_str_syms(ps->o.bindings_keysTapExpose, &mw->keysyms_TapExpose);
+	keys_str_syms(ps->o.bindings_keysPivotPaging, &mw->keysyms_PivotPaging);
+	keys_str_syms(ps->o.bindings_keysTapPaging, &mw->keysyms_TapPaging);
+
+	// convert the arrays of KeySyms into arrays of KeyCodes, for this specific Display
+	keysyms_arr_keycodes(dpy, mw->keysyms_Up, &mw->keycodes_Up);
+	keysyms_arr_keycodes(dpy, mw->keysyms_Down, &mw->keycodes_Down);
+	keysyms_arr_keycodes(dpy, mw->keysyms_Left, &mw->keycodes_Left);
+	keysyms_arr_keycodes(dpy, mw->keysyms_Right, &mw->keycodes_Right);
+	keysyms_arr_keycodes(dpy, mw->keysyms_Next, &mw->keycodes_Next);
+	keysyms_arr_keycodes(dpy, mw->keysyms_Cancel, &mw->keycodes_Cancel);
+	keysyms_arr_keycodes(dpy, mw->keysyms_Select, &mw->keycodes_Select);
+	keysyms_arr_keycodes(dpy, mw->keysyms_Iconify, &mw->keycodes_Iconify);
+	keysyms_arr_keycodes(dpy, mw->keysyms_Shade, &mw->keycodes_Shade);
+	keysyms_arr_keycodes(dpy, mw->keysyms_Close, &mw->keycodes_Close);
+	keysyms_arr_keycodes(dpy, mw->keysyms_PivotSwitch, &mw->keycodes_PivotSwitch);
+	keysyms_arr_keycodes(dpy, mw->keysyms_TapSwitch, &mw->keycodes_TapSwitch);
+	keysyms_arr_keycodes(dpy, mw->keysyms_PivotExpose, &mw->keycodes_PivotExpose);
+	keysyms_arr_keycodes(dpy, mw->keysyms_TapExpose, &mw->keycodes_TapExpose);
+	keysyms_arr_keycodes(dpy, mw->keysyms_PivotPaging, &mw->keycodes_PivotPaging);
+	keysyms_arr_keycodes(dpy, mw->keysyms_TapPaging, &mw->keycodes_TapPaging);
+
+	mainwin_grab_pivot_keys(ps, mw);
 
 	modkeymasks_str_enums(ps->o.bindings_masksReverse, &mw->keymasks_Reverse);
 

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -481,6 +481,8 @@ void
 mainwin_destroy(MainWin *mw) {
 	session_t *ps = mw->ps; 
 
+	XUngrabKey(ps->dpy, AnyKey, AnyModifier, DefaultRootWindow(ps->dpy));
+
 	// Free all clients associated with this main window
 	dlist_free_with_func(mw->clients, (dlist_free_func) clientwin_destroy);
 

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -125,6 +125,34 @@ mainwin_create_err:
 	return NULL;
 }
 
+static
+int keycode2mask(KeySym keycode)
+{
+	switch (keycode) {
+		case XK_Shift_L:
+		case XK_Shift_R:
+			return ShiftMask;
+		case XK_Caps_Lock:
+			return LockMask;
+		case XK_Control_L:
+		case XK_Control_R:
+			return ControlMask;
+		case XK_Alt_L:
+		case XK_Alt_R:
+		case XK_Meta_L:
+			return Mod1Mask;
+		case XK_Num_Lock:
+			return Mod2Mask;
+		case XK_Super_L:
+		case XK_Super_R:
+			return Mod4Mask;
+		case XK_ISO_Level3_Shift:
+		case XK_Mode_switch:
+			return Mod5Mask;
+	}
+	return AnyModifier;
+}
+
 void
 mainwin_grab_pivot_keys(session_t *ps, MainWin *mw) {
 	Display * const dpy = ps->dpy;
@@ -132,40 +160,69 @@ mainwin_grab_pivot_keys(session_t *ps, MainWin *mw) {
 	XUngrabKey(ps->dpy, AnyKey, AnyModifier, DefaultRootWindow(dpy));
 
 	if (mw->keycodes_PivotSwitch) {
-		for (int i=0; mw->keycodes_PivotSwitch[i] != '\0'; i++) {
-			int keycode = mw->keycodes_PivotSwitch[i];
-			int grabkey_status =
-					XGrabKey(ps->dpy, keycode, AnyModifier,
-							DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
-			if (grabkey_status != 1) {
-				printfef(true, "(): grabbing pivot key %s failed",
-						mw->ps->o.bindings_keysPivotSwitch);
+		if (mw->keycodes_TapSwitch) {
+			int modifiermask = 0;
+			for (int i=0; mw->keycodes_PivotSwitch[i] != '\0'; i++)
+				modifiermask |= keycode2mask(mw->keysyms_PivotSwitch[i]);
+			for (int i=0; mw->keycodes_TapSwitch[i] != '\0'; i++) {
+				int keycode = mw->keycodes_TapSwitch[i];
+				XGrabKey(ps->dpy, keycode,
+						modifiermask,
+						DefaultRootWindow(dpy), True,
+						GrabModeAsync, GrabModeAsync);
+			}
+		}
+		else {
+			for (int i=0; mw->keycodes_PivotSwitch[i] != '\0'; i++) {
+				int keycode = mw->keycodes_PivotSwitch[i];
+				XGrabKey(ps->dpy, keycode,
+						AnyModifier,
+						DefaultRootWindow(dpy), True,
+						GrabModeAsync, GrabModeAsync);
 			}
 		}
 	}
 
 	if (mw->keycodes_PivotExpose) {
-		for (int i=0; mw->keycodes_PivotExpose[i] != '\0'; i++) {
-			int keycode = mw->keycodes_PivotExpose[i];
-			int grabkey_status =
-					XGrabKey(ps->dpy, keycode, AnyModifier,
-							DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
-			if (grabkey_status != 1) {
-				printfef(true, "(): grabbing pivot key %s failed",
-						mw->ps->o.bindings_keysPivotExpose);
+		if (mw->keycodes_TapExpose) {
+			int modifiermask = 0;
+			for (int i=0; mw->keycodes_PivotExpose[i] != '\0'; i++)
+				modifiermask |= keycode2mask(mw->keysyms_PivotExpose[i]);
+			for (int i=0; mw->keycodes_TapExpose[i] != '\0'; i++) {
+				int keycode = mw->keycodes_TapExpose[i];
+				XGrabKey(ps->dpy, keycode,
+						modifiermask,
+						DefaultRootWindow(dpy), True,
+						GrabModeAsync, GrabModeAsync);
+			}
+		}
+		else {
+			for (int i=0; mw->keycodes_PivotExpose[i] != '\0'; i++) {
+				int keycode = mw->keycodes_PivotExpose[i];
+				XGrabKey(ps->dpy, keycode, AnyModifier,
+						DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
 			}
 		}
 	}
 
 	if (mw->keycodes_PivotPaging) {
-		for (int i=0; mw->keycodes_PivotPaging[i] != '\0'; i++) {
-			int keycode = mw->keycodes_PivotPaging[i];
-			int grabkey_status =
-					XGrabKey(ps->dpy, keycode, AnyModifier,
-							DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
-			if (grabkey_status != 1) {
-				printfef(true, "(): grabbing pivot key %s failed",
-						mw->ps->o.bindings_keysPivotPaging);
+		if (mw->keycodes_TapPaging) {
+			int modifiermask = 0;
+			for (int i=0; mw->keycodes_PivotPaging[i] != '\0'; i++)
+				modifiermask |= keycode2mask(mw->keysyms_PivotPaging[i]);
+			for (int i=0; mw->keycodes_TapPaging[i] != '\0'; i++) {
+				int keycode = mw->keycodes_TapPaging[i];
+				XGrabKey(ps->dpy, keycode,
+						modifiermask,
+						DefaultRootWindow(dpy), True,
+						GrabModeAsync, GrabModeAsync);
+			}
+		}
+		else {
+			for (int i=0; mw->keycodes_PivotPaging[i] != '\0'; i++) {
+				int keycode = mw->keycodes_PivotPaging[i];
+				XGrabKey(ps->dpy, keycode, AnyModifier,
+						DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
 			}
 		}
 	}

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -165,6 +165,33 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keysyms_arr_keycodes(dpy, mw->keysyms_PivotPaging, &mw->keycodes_PivotPaging);
 	keysyms_arr_keycodes(dpy, mw->keysyms_TapPaging, &mw->keycodes_TapPaging);
 
+	if (mw->keycodes_PivotSwitch) {
+		for (int i=0; mw->keycodes_PivotSwitch[i] != '\0'; i++) {
+			int keycode = mw->keycodes_PivotSwitch[i];
+			int grabkey_status =
+					XGrabKey(ps->dpy, keycode, AnyModifier,
+							DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
+		}
+	}
+
+	if (mw->keycodes_PivotExpose) {
+		for (int i=0; mw->keycodes_PivotExpose[i] != '\0'; i++) {
+			int keycode = mw->keycodes_PivotExpose[i];
+			int grabkey_status =
+					XGrabKey(ps->dpy, keycode, AnyModifier,
+							DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
+		}
+	}
+
+	if (mw->keycodes_PivotPaging) {
+		for (int i=0; mw->keycodes_PivotPaging[i] != '\0'; i++) {
+			int keycode = mw->keycodes_PivotPaging[i];
+			int grabkey_status =
+					XGrabKey(ps->dpy, keycode, AnyModifier,
+							DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
+		}
+	}
+
 	modkeymasks_str_enums(ps->o.bindings_masksReverse, &mw->keymasks_Reverse);
 
 	// we check all possible pairs, one pair at a time. This is in a specific order, to give a more helpful error msg

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -165,6 +165,8 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keysyms_arr_keycodes(dpy, mw->keysyms_PivotPaging, &mw->keycodes_PivotPaging);
 	keysyms_arr_keycodes(dpy, mw->keysyms_TapPaging, &mw->keycodes_TapPaging);
 
+	XUngrabKey(ps->dpy, AnyKey, AnyModifier, DefaultRootWindow(dpy));
+
 	if (mw->keycodes_PivotSwitch) {
 		for (int i=0; mw->keycodes_PivotSwitch[i] != '\0'; i++) {
 			int keycode = mw->keycodes_PivotSwitch[i];

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -168,7 +168,7 @@ mainwin_grab_pivot_keys(session_t *ps, MainWin *mw) {
 				int keycode = mw->keycodes_TapSwitch[i];
 				XGrabKey(ps->dpy, keycode,
 						modifiermask,
-						DefaultRootWindow(dpy), True,
+						DefaultRootWindow(ps->dpy), True,
 						GrabModeAsync, GrabModeAsync);
 			}
 		}
@@ -177,7 +177,7 @@ mainwin_grab_pivot_keys(session_t *ps, MainWin *mw) {
 				int keycode = mw->keycodes_PivotSwitch[i];
 				XGrabKey(ps->dpy, keycode,
 						AnyModifier,
-						DefaultRootWindow(dpy), True,
+						DefaultRootWindow(ps->dpy), True,
 						GrabModeAsync, GrabModeAsync);
 			}
 		}
@@ -192,7 +192,7 @@ mainwin_grab_pivot_keys(session_t *ps, MainWin *mw) {
 				int keycode = mw->keycodes_TapExpose[i];
 				XGrabKey(ps->dpy, keycode,
 						modifiermask,
-						DefaultRootWindow(dpy), True,
+						DefaultRootWindow(ps->dpy), True,
 						GrabModeAsync, GrabModeAsync);
 			}
 		}
@@ -200,7 +200,8 @@ mainwin_grab_pivot_keys(session_t *ps, MainWin *mw) {
 			for (int i=0; mw->keycodes_PivotExpose[i] != '\0'; i++) {
 				int keycode = mw->keycodes_PivotExpose[i];
 				XGrabKey(ps->dpy, keycode, AnyModifier,
-						DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
+						DefaultRootWindow(ps->dpy), True,
+						GrabModeAsync, GrabModeAsync);
 			}
 		}
 	}
@@ -214,7 +215,7 @@ mainwin_grab_pivot_keys(session_t *ps, MainWin *mw) {
 				int keycode = mw->keycodes_TapPaging[i];
 				XGrabKey(ps->dpy, keycode,
 						modifiermask,
-						DefaultRootWindow(dpy), True,
+						DefaultRootWindow(ps->dpy), True,
 						GrabModeAsync, GrabModeAsync);
 			}
 		}
@@ -222,7 +223,8 @@ mainwin_grab_pivot_keys(session_t *ps, MainWin *mw) {
 			for (int i=0; mw->keycodes_PivotPaging[i] != '\0'; i++) {
 				int keycode = mw->keycodes_PivotPaging[i];
 				XGrabKey(ps->dpy, keycode, AnyModifier,
-						DefaultRootWindow(dpy), True, GrabModeAsync, GrabModeAsync);
+						DefaultRootWindow(ps->dpy), True,
+						GrabModeAsync, GrabModeAsync);
 			}
 		}
 	}

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -54,7 +54,6 @@ struct _mainwin_t {
 	KeySym *keysyms_Down;
 	KeySym *keysyms_Left;
 	KeySym *keysyms_Right;
-	KeySym *keysyms_Prev;
 	KeySym *keysyms_Next;
 	KeySym *keysyms_Cancel;
 	KeySym *keysyms_Select;
@@ -72,7 +71,6 @@ struct _mainwin_t {
 	KeyCode *keycodes_Down;
 	KeyCode *keycodes_Left;
 	KeyCode *keycodes_Right;
-	KeyCode *keycodes_Prev;
 	KeyCode *keycodes_Next;
 	KeyCode *keycodes_Cancel;
 	KeyCode *keycodes_Select;
@@ -85,6 +83,8 @@ struct _mainwin_t {
 	KeyCode *keycodes_TapExpose;
 	KeyCode *keycodes_PivotPaging;
 	KeyCode *keycodes_TapPaging;
+
+	int *keymasks_Reverse;
 
 	bool refocus;
 	bool mapped;

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -62,8 +62,11 @@ struct _mainwin_t {
 	KeySym *keysyms_Shade;
 	KeySym *keysyms_Close;
 	KeySym *keysyms_PivotSwitch;
+	KeySym *keysyms_TapSwitch;
 	KeySym *keysyms_PivotExpose;
+	KeySym *keysyms_TapExpose;
 	KeySym *keysyms_PivotPaging;
+	KeySym *keysyms_TapPaging;
 
 	KeyCode *keycodes_Up;
 	KeyCode *keycodes_Down;
@@ -77,8 +80,11 @@ struct _mainwin_t {
 	KeyCode *keycodes_Shade;
 	KeyCode *keycodes_Close;
 	KeyCode *keycodes_PivotSwitch;
+	KeyCode *keycodes_TapSwitch;
 	KeyCode *keycodes_PivotExpose;
+	KeyCode *keycodes_TapExpose;
 	KeyCode *keycodes_PivotPaging;
+	KeyCode *keycodes_TapPaging;
 
 	bool refocus;
 	bool mapped;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1205,7 +1205,14 @@ mainloop(session_t *ps, bool activate_on_start) {
 #endif
 			Window wid = ev_window(ps, &ev);
 
-			if (mw && MotionNotify == ev.type)
+			if (mw && ev.type == KeyPress
+					&& wid == DefaultRootWindow(ps->dpy)) {
+				// pivot tapping scenario
+				XKeyEvent * const evk = &ev.xkey;
+				if (arr_keycodes_includes(mw->keycodes_TapSwitch, evk->keycode))
+					die = mainwin_handle(mw, &ev);
+			}
+			else if (mw && MotionNotify == ev.type)
 			{
 				// when mouse move within a client window, focus on it
 				if (wid) {

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -973,6 +973,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 	bool pending_damage = false;
 	long last_rendered = 0L;
 	enum layoutmode layout = LAYOUTMODE_EXPOSE;
+	bool toggling = true;
 	bool animating = activate;
 	long first_animated = 0L;
 	bool first_animating = false;
@@ -1097,7 +1098,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 		// the placement of this code allows MainWin not to map
 		// so that previews may not show for switch
 		// when the pivot key is held for only short time
-		if (mw)
+		if (mw && !toggling)
 		{
 			bool pivotTerminate = false;
 			if (layout == LAYOUTMODE_SWITCH && mw->keycodes_PivotSwitch) {
@@ -1384,6 +1385,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 				if (switchTrigger) {
 					animating = activate = true;
 					layout = LAYOUTMODE_SWITCH;
+					toggling = false;
 					if (ps->mainwin->keycodes_TapSwitch)
 						ps->o.focus_initial = 1;
 				}
@@ -1397,6 +1399,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 				if (exposeTrigger) {
 					animating = activate = true;
 					layout = LAYOUTMODE_EXPOSE;
+					toggling = false;
 					if (ps->mainwin->keycodes_TapExpose)
 						ps->o.focus_initial = 1;
 				}
@@ -1410,6 +1413,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 				if (pagingTrigger) {
 					animating = activate = true;
 					layout = LAYOUTMODE_PAGING;
+					toggling = false;
 					if (ps->mainwin->keycodes_TapPaging)
 						ps->o.focus_initial = 1;
 				}
@@ -1439,6 +1443,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 					{
 						printfdf(false, "(): skippy activating, mode=%d", layout);
 						animating = activate = true;
+						toggling = true;
 						if ((piped_input | PIPECMD_PREV | PIPECMD_NEXT)
 								== (PIPECMD_SWITCH | PIPECMD_PREV | PIPECMD_NEXT)) {
 							ps->o.mode = PROGMODE_SWITCH;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1376,6 +1376,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 		poll(r_fd, (r_fd[1].fd >= 0 ? 2: 1), timeout);
 
 		// pivot triggering
+		if (!mw)
 		{
 			if (ps->mainwin->keycodes_PivotSwitch) {
 				bool switchTrigger = pivoting(ps, ps->mainwin->keycodes_PivotSwitch);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1383,6 +1383,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 					switchTrigger = switchTrigger
 							&& pivoting(ps, ps->mainwin->keycodes_TapSwitch);
 				if (switchTrigger) {
+					ps->o.mode = PROGMODE_SWITCH;
 					animating = activate = true;
 					layout = LAYOUTMODE_SWITCH;
 					toggling = false;
@@ -1397,6 +1398,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 					exposeTrigger = Expose
 							&& pivoting(ps, ps->mainwin->keycodes_TapExpose);
 				if (exposeTrigger) {
+					ps->o.mode = PROGMODE_EXPOSE;
 					animating = activate = true;
 					layout = LAYOUTMODE_EXPOSE;
 					toggling = false;
@@ -1411,6 +1413,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 					pagingTrigger = pagingTrigger
 							&& pivoting(ps, ps->mainwin->keycodes_TapPaging);
 				if (pagingTrigger) {
+					ps->o.mode = PROGMODE_PAGING;
 					animating = activate = true;
 					layout = LAYOUTMODE_PAGING;
 					toggling = false;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1933,6 +1933,13 @@ load_config_file(session_t *ps)
     ps->o.bindings_keysPivotPaging = mstrdup(config_get(config, "hotkeys", "pagingPivot", ""));
     ps->o.bindings_keysTapPaging = mstrdup(config_get(config, "hotkeys", "pagingTap", ""));
 
+    check_keysyms(ps->o.config_path, ": [hotkeys] switchPivot =", ps->o.bindings_keysPivotSwitch);
+    check_keysyms(ps->o.config_path, ": [hotkeys] switchTap =", ps->o.bindings_keysTapSwitch);
+    check_keysyms(ps->o.config_path, ": [hotkeys] exposePivot =", ps->o.bindings_keysPivotExpose);
+    check_keysyms(ps->o.config_path, ": [hotkeys] exposeTap =", ps->o.bindings_keysTapExpose);
+    check_keysyms(ps->o.config_path, ": [hotkeys] pagingPivot =", ps->o.bindings_keysPivotPaging);
+    check_keysyms(ps->o.config_path, ": [hotkeys] pagingTap =", ps->o.bindings_keysTapPaging);
+
     // load keybindings settings
     ps->o.bindings_keysUp = mstrdup(config_get(config, "bindings", "keysUp", "Up"));
     ps->o.bindings_keysDown = mstrdup(config_get(config, "bindings", "keysDown", "Down"));
@@ -1958,13 +1965,6 @@ load_config_file(session_t *ps)
     check_keysyms(ps->o.config_path, ": [bindings] keysIconify =", ps->o.bindings_keysIconify);
     check_keysyms(ps->o.config_path, ": [bindings] keysShade =", ps->o.bindings_keysShade);
     check_keysyms(ps->o.config_path, ": [bindings] keysClose =", ps->o.bindings_keysClose);
-
-    check_keysyms(ps->o.config_path, ": [hotkeys] switchPivot =", ps->o.bindings_keysPivotSwitch);
-    check_keysyms(ps->o.config_path, ": [hotkeys] switchTap =", ps->o.bindings_keysTapSwitch);
-    check_keysyms(ps->o.config_path, ": [hotkeys] exposePivot =", ps->o.bindings_keysPivotExpose);
-    check_keysyms(ps->o.config_path, ": [hotkeys] exposeTap =", ps->o.bindings_keysTapExpose);
-    check_keysyms(ps->o.config_path, ": [hotkeys] pagingPivot =", ps->o.bindings_keysPivotPaging);
-    check_keysyms(ps->o.config_path, ": [hotkeys] pagingTap =", ps->o.bindings_keysTapPaging);
 
 	if (!parse_cliop(ps, config_get(config, "bindings", "miwMouse1", "focus"), &ps->o.bindings_miwMouse[1])
 			|| !parse_cliop(ps, config_get(config, "bindings", "miwMouse2", "close-ewmh"), &ps->o.bindings_miwMouse[2])

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1951,7 +1951,7 @@ load_config_file(session_t *ps)
     check_keysyms(ps->o.config_path, ": [bindings] keysDown =", ps->o.bindings_keysDown);
     check_keysyms(ps->o.config_path, ": [bindings] keysLeft =", ps->o.bindings_keysLeft);
     check_keysyms(ps->o.config_path, ": [bindings] keysRight =", ps->o.bindings_keysRight);
-    check_keysyms(ps->o.config_path, ": [bindings] keysReverse =", ps->o.bindings_masksReverse);
+    check_modmasks(ps->o.config_path, ": [bindings] keysReverse =", ps->o.bindings_masksReverse);
     check_keysyms(ps->o.config_path, ": [bindings] keysNext =", ps->o.bindings_keysNext);
     check_keysyms(ps->o.config_path, ": [bindings] keysCancel =", ps->o.bindings_keysCancel);
     check_keysyms(ps->o.config_path, ": [bindings] keysSelect =", ps->o.bindings_keysSelect);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1935,8 +1935,8 @@ load_config_file(session_t *ps)
     ps->o.bindings_keysDown = mstrdup(config_get(config, "bindings", "keysDown", "Down"));
     ps->o.bindings_keysLeft = mstrdup(config_get(config, "bindings", "keysLeft", "Left"));
     ps->o.bindings_keysRight = mstrdup(config_get(config, "bindings", "keysRight", "Right"));
-    ps->o.bindings_keysPrev = mstrdup(config_get(config, "bindings", "keysPrev", "p"));
-    ps->o.bindings_keysNext = mstrdup(config_get(config, "bindings", "keysNext", "n"));
+    ps->o.bindings_keysNext = mstrdup(config_get(config, "bindings", "keysNext", "Tab"));
+    ps->o.bindings_masksReverse = mstrdup(config_get(config, "bindings", "keysReverse", "ShiftMask"));
     ps->o.bindings_keysCancel = mstrdup(config_get(config, "bindings", "keysCancel", "Escape"));
     ps->o.bindings_keysSelect = mstrdup(config_get(config, "bindings", "keysSelect", "Return space"));
     ps->o.bindings_keysIconify = mstrdup(config_get(config, "bindings", "keysIconify", "1"));
@@ -1948,7 +1948,7 @@ load_config_file(session_t *ps)
     check_keysyms(ps->o.config_path, ": [bindings] keysDown =", ps->o.bindings_keysDown);
     check_keysyms(ps->o.config_path, ": [bindings] keysLeft =", ps->o.bindings_keysLeft);
     check_keysyms(ps->o.config_path, ": [bindings] keysRight =", ps->o.bindings_keysRight);
-    check_keysyms(ps->o.config_path, ": [bindings] keysPrev =", ps->o.bindings_keysPrev);
+    check_keysyms(ps->o.config_path, ": [bindings] keysReverse =", ps->o.bindings_masksReverse);
     check_keysyms(ps->o.config_path, ": [bindings] keysNext =", ps->o.bindings_keysNext);
     check_keysyms(ps->o.config_path, ": [bindings] keysCancel =", ps->o.bindings_keysCancel);
     check_keysyms(ps->o.config_path, ": [bindings] keysSelect =", ps->o.bindings_keysSelect);
@@ -2252,7 +2252,7 @@ main_end:
 			free(ps->o.bindings_keysDown);
 			free(ps->o.bindings_keysLeft);
 			free(ps->o.bindings_keysRight);
-			free(ps->o.bindings_keysPrev);
+			free(ps->o.bindings_masksReverse);
 			free(ps->o.bindings_keysNext);
 			free(ps->o.bindings_keysCancel);
 			free(ps->o.bindings_keysSelect);

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -265,8 +265,11 @@ typedef struct {
 	char *bindings_keysShade;
 	char *bindings_keysClose;
 	char *bindings_keysPivotSwitch;
+	char *bindings_keysTapSwitch;
 	char *bindings_keysPivotExpose;
+	char *bindings_keysTapExpose;
 	char *bindings_keysPivotPaging;
+	char *bindings_keysTapPaging;
 } options_t;
 
 #define OPTIONST_INIT { \

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -257,8 +257,8 @@ typedef struct {
 	char *bindings_keysDown;
 	char *bindings_keysLeft;
 	char *bindings_keysRight;
-	char *bindings_keysPrev;
 	char *bindings_keysNext;
+	char *bindings_masksReverse;
 	char *bindings_keysCancel;
 	char *bindings_keysSelect;
 	char *bindings_keysIconify;


### PR DESCRIPTION
In #133, while using a single "pivot" key to activate skippy-xd, keyboard navigation with up/down/left/right/next/prev cannot be done. This is because when using xbindkeys or similar 3rd party hot key apps to activate skippy-xd, these 3rd party apps grab the keys and become the exclusive receiver of the keyboard events. To be precise, they swallow the keyboard events of the pivot key, as well as all other keyboard events while the pivot key is being held. Hence, a single "pivot" key is only semi-functional under the implementation of skippy-xd so far.

Is the "pivot" logic so important? What are the pros/cons?

Pivoting means to hold a key (e.g. Alt), to maintain skippy-xd activation; when the pivot key is released, then skippy-xd is inactivated, selecting the highlighted window. This is obviously essential for Alt-Tab feature, where holding Alt and pressing Tab activates skippy-xd, and subsequent Tab tapping highlights the next window.

An alternative pivoting set up is single pivoting, where e.g. the Super key is designated the pivot key, and holding this key alone activates skippy-xd, and the user navigates with up/down/left/right/next/prev and/or the mouse. A user may want to do this with expose and/or paging. This set up is fun to use, because of its feedback, but would be physically taxing to hold the pivot keys long. A good use would be to use bind mouse keys (e.g.mouse buttons 6/7) to expose and paging, so the user can quickly select windows/virtual desktops without leaving the mouse, and with minimal mouse movement.

Meanwhile, the "toggle" mode, where no pivot keys need to be held, and each key invocation toggle skippy-xd activation on/off, is obviously still important for expose/paging (Alt-Tab is strictly pivoting of course). So we have this dilemma:
1. Toggling mode is important for expose and paging.
2. Pivot-tapping is essential for Alt-Tab.
3. Single pivot is a fun but not essential feature.
4. Single pivot may be good for mouse-only use.
5. Currently toggle mode and pivot-tapping modes work flawlessly, while single pivot mode is only semi-functional.
6. Toggle mode and pivot mode can co-exist between switch/expose/paging, but NOT co-exist within one metaphor.

Thus, this PR redesigns skippy-xd interface for factors 4, 5, 6. Toggle mode and pivot mode can co-exist within one metaphor, and single pivot mode is implemented properly.

To achieve this, skippy-xd needs to keep track of whether the current activation is in toggle mode or pivot mode (easy), and to trigger pivot mode by listening to hot keys of both the pivot key (e.g. Alt) and tap key (e.g. Tab), so that both these keys need to be specified in the config file. When both keys are specified, then we have the pivot-tapping set up; when only the pivot key is specified, then we have the single pivot set up. Toggle mode is triggered through the existing pipe command, e.g. `skippy-xd --expose` or `skippy-xd --paging`, and is completely independent of the pivoting mode. For example, a user can use xbindkeys to toggle expose with `Ctrl E`, while simultaneously set up the `Super` key as single pivot for expose.

With this, the command line parameters `--next` and `--prev` become non-applicable and will be removed. Along with this the window selection logic also requires minor change. Previously, reverse Alt-Tab can simply be set up with using xbindkeys to bind `Shift Alt-Tab` with `skippy-xd --switch --prev`. Now a keysReverse mask (default Shift) is added to the config file to achieve the same effect. The reverse mask is applied only to the next navigation, not the up/down/left/right directions.

This is a big change and changes the user interface significantly and will require significant testing before merging.

Closing #133 