### PR TITLE
Revamp pipe protocol and pivot key interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-## BREAKING! ALT-TAB command is changed to
-### skippy-xd --switch --pivot --next
-
-
-
 Welcome to skippy-xd!
 
 Skippy-xd is a lightweight, window-manager-agnostic window selector on X server. With skippy, you get live-preview on your alt-tab motions; you get the much coveted expose feature from Mac; you get a handy overview of all your virtual desktops in one glance with paging mode.
@@ -37,7 +32,7 @@ make
 make install
 
 skippy-xd --start-daemon
-skippy-xd --switch --pivot --next
+skippy-xd --switch --next
 skippy-xd --expose
 skippy-xd --paging
 ```

--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -187,10 +187,3 @@ miwMouse2 = close-ewmh
 miwMouse3 = iconify
 miwMouse4 = keysNext
 miwMouse5 = keysPrev
-
-# The "pivot" keys are the Alt in Alt-Tab
-# During pivot mode, the key has to be held
-# And when the key is released, skippy-xd selects the highlighted window.
-keysPivotSwitch = Alt_L
-keysPivotExpose = 
-keysPivotPaging = 

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -141,9 +141,6 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keys_str_syms(ps->o.bindings_keysIconify, &mw->keysyms_Iconify);
 	keys_str_syms(ps->o.bindings_keysShade, &mw->keysyms_Shade);
 	keys_str_syms(ps->o.bindings_keysClose, &mw->keysyms_Close);
-	keys_str_syms(ps->o.bindings_keysPivotSwitch, &mw->keysyms_PivotSwitch);
-	keys_str_syms(ps->o.bindings_keysPivotExpose, &mw->keysyms_PivotExpose);
-	keys_str_syms(ps->o.bindings_keysPivotPaging, &mw->keysyms_PivotPaging);
 
 	// convert the arrays of KeySyms into arrays of KeyCodes, for this specific Display
 	keysyms_arr_keycodes(dpy, mw->keysyms_Up, &mw->keycodes_Up);
@@ -157,9 +154,6 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keysyms_arr_keycodes(dpy, mw->keysyms_Iconify, &mw->keycodes_Iconify);
 	keysyms_arr_keycodes(dpy, mw->keysyms_Shade, &mw->keycodes_Shade);
 	keysyms_arr_keycodes(dpy, mw->keysyms_Close, &mw->keycodes_Close);
-	keysyms_arr_keycodes(dpy, mw->keysyms_PivotSwitch, &mw->keycodes_PivotSwitch);
-	keysyms_arr_keycodes(dpy, mw->keysyms_PivotExpose, &mw->keycodes_PivotExpose);
-	keysyms_arr_keycodes(dpy, mw->keysyms_PivotPaging, &mw->keycodes_PivotPaging);
 
 	// we check all possible pairs, one pair at a time. This is in a specific order, to give a more helpful error msg
 	check_keybindings_conflict(ps->o.config_path, "keysUp", mw->keysyms_Up, "keysDown", mw->keysyms_Down);
@@ -167,19 +161,15 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	check_keybindings_conflict(ps->o.config_path, "keysUp", mw->keysyms_Up, "keysRight", mw->keysyms_Right);
 	check_keybindings_conflict(ps->o.config_path, "keysUp", mw->keysyms_Up, "keysCancel", mw->keysyms_Cancel);
 	check_keybindings_conflict(ps->o.config_path, "keysUp", mw->keysyms_Up, "keysSelect", mw->keysyms_Select);
-	//check_keybindings_conflict(ps->o.config_path, "keysUp", mw->keysyms_Up, "keysPivot", mw->keysyms_Pivot);
 	check_keybindings_conflict(ps->o.config_path, "keysDown", mw->keysyms_Down, "keysLeft", mw->keysyms_Left);
 	check_keybindings_conflict(ps->o.config_path, "keysDown", mw->keysyms_Down, "keysRight", mw->keysyms_Right);
 	check_keybindings_conflict(ps->o.config_path, "keysDown", mw->keysyms_Down, "keysCancel", mw->keysyms_Cancel);
 	check_keybindings_conflict(ps->o.config_path, "keysDown", mw->keysyms_Down, "keysSelect", mw->keysyms_Select);
-	//check_keybindings_conflict(ps->o.config_path, "keysDown", mw->keysyms_Down, "keysPivot", mw->keysyms_Pivot);
 	check_keybindings_conflict(ps->o.config_path, "keysLeft", mw->keysyms_Left, "keysRight", mw->keysyms_Right);
 	check_keybindings_conflict(ps->o.config_path, "keysLeft", mw->keysyms_Left, "keysCancel", mw->keysyms_Cancel);
 	check_keybindings_conflict(ps->o.config_path, "keysLeft", mw->keysyms_Left, "keysSelect", mw->keysyms_Select);
-	//check_keybindings_conflict(ps->o.config_path, "keysLeft", mw->keysyms_Left, "keysPivot", mw->keysyms_Pivot);
 	check_keybindings_conflict(ps->o.config_path, "keysRight", mw->keysyms_Prev, "keysCancel", mw->keysyms_Cancel);
 	check_keybindings_conflict(ps->o.config_path, "keysRight", mw->keysyms_Prev, "keysSelect", mw->keysyms_Select);
-	//check_keybindings_conflict(ps->o.config_path, "keysRight", mw->keysyms_Prev, "keysPivot", mw->keysyms_Pivot);
 	check_keybindings_conflict(ps->o.config_path, "keysPrev", mw->keysyms_Prev, "keysCancel", mw->keysyms_Cancel);
 	check_keybindings_conflict(ps->o.config_path, "keysPrev", mw->keysyms_Prev, "keysSelect", mw->keysyms_Select);
 	check_keybindings_conflict(ps->o.config_path, "keysNext", mw->keysyms_Next, "keysCancel", mw->keysyms_Cancel);
@@ -484,9 +474,6 @@ mainwin_destroy(MainWin *mw) {
 	free(mw->keysyms_Iconify);
 	free(mw->keysyms_Shade);
 	free(mw->keysyms_Close);
-	free(mw->keysyms_PivotSwitch);
-	free(mw->keysyms_PivotExpose);
-	free(mw->keysyms_PivotPaging);
 
 	free(mw->keycodes_Up);
 	free(mw->keycodes_Down);
@@ -499,9 +486,6 @@ mainwin_destroy(MainWin *mw) {
 	free(mw->keycodes_Iconify);
 	free(mw->keycodes_Shade);
 	free(mw->keycodes_Close);
-	free(mw->keycodes_PivotSwitch);
-	free(mw->keycodes_PivotExpose);
-	free(mw->keycodes_PivotPaging);
 
 	free(mw);
 }

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -61,9 +61,6 @@ struct _mainwin_t {
 	KeySym *keysyms_Iconify;
 	KeySym *keysyms_Shade;
 	KeySym *keysyms_Close;
-	KeySym *keysyms_PivotSwitch;
-	KeySym *keysyms_PivotExpose;
-	KeySym *keysyms_PivotPaging;
 
 	KeyCode *keycodes_Up;
 	KeyCode *keycodes_Down;
@@ -76,9 +73,6 @@ struct _mainwin_t {
 	KeyCode *keycodes_Iconify;
 	KeyCode *keycodes_Shade;
 	KeyCode *keycodes_Close;
-	KeyCode *keycodes_PivotSwitch;
-	KeyCode *keycodes_PivotExpose;
-	KeyCode *keycodes_PivotPaging;
 
 	bool refocus;
 	bool mapped;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1706,7 +1706,7 @@ show_help() {
 			"  [no command]        - activate expose once without daemon.\n"
 			"\n"
 			"  --help              - show this message.\n"
-			"  --debug-log          - enable debugging logs.\n"
+			"  --debug-log         - enable debugging logs.\n"
 			"\n"
 			"  --config            - load/reload configuration file from specifed path.\n"
 			"  --config-reload     - reload configuration file without changing path.\n"

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -497,6 +497,10 @@ receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 			printfdf(false, "(): received parameter %d%s", (*param)[i], (*str)[i]);
 		}
 	}
+
+	if (buffer)
+		free(buffer);
+
 	return master_command;
 }
 
@@ -1608,6 +1612,13 @@ mainloop(session_t *ps, bool activate_on_start) {
 						clientwin_render(mw->client_to_focus);
 				}
 			}
+
+			// free receive_string_in_daemon_via_fifo() paramters
+			if (param)
+				free(param);
+			for (int i=0; i<nparams; i++)
+				if (str[i])
+					free(str[i]);
 		}
 
 		if (POLLHUP & r_fd[1].revents) {

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -420,12 +420,12 @@ send_string_command_to_daemon_via_fifo(
 		}
 	}
 
-	printfdf(true, "(): sending string command to pipe of length %d",
+	printfdf(false, "(): sending string command to pipe of length %d",
 			(int)strlen(command) + 1);
 
 	char final_cmd[strlen(command)+1];
 	sprintf(final_cmd, "%c%s", (char)strlen(command), command);
-	printfdf(true, "(): string command: %s", final_cmd);
+	printfdf(false, "(): string command: %s", final_cmd);
 
 	int fp = open(pipePath, O_WRONLY);
 	int bytes_written = write(fp, final_cmd, strlen(command)+1);
@@ -462,7 +462,7 @@ receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 	char master_command = buffer[0];
 
 	if ((master_command & PIPECMD_MULTI_BYTE) == 0) {
-		printfdf(true, "(): received single byte command %d", master_command);
+		printfdf(false, "(): received single byte command %d", master_command);
 		*nparams = 0;
 		param = NULL;
 		str = NULL;
@@ -474,8 +474,7 @@ receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 		}
 
 		*nparams = buffer[1];
-		printfdf(true, "(): full command %s", buffer);
-		printfdf(true, "(): received multi-byte command %d of %d bytes and %d parameters",
+		printfdf(false, "(): received multi-byte command %d of %d bytes and %d parameters",
 				master_command, cmdlen, *nparams);
 		*param = malloc(*nparams * sizeof(char*));
 		*str = malloc(*nparams * sizeof(char*));
@@ -486,7 +485,7 @@ receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 			k++;
 
 			char nchar = buffer[k];
-			printfdf(true, "(): parameter %d takes %d bytes...",
+			printfdf(false, "(): parameter %d takes %d bytes...",
 					(*param)[i], nchar);
 			k++;
 
@@ -495,7 +494,7 @@ receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 			(*str)[i][(int)nchar] = '\0';
 			k += nchar;
 
-			printfdf(true, "(): received parameter %d%s", (*param)[i], (*str)[i]);
+			printfdf(false, "(): received parameter %d%s", (*param)[i], (*str)[i]);
 		}
 	}
 	return master_command;
@@ -1570,17 +1569,17 @@ mainloop(session_t *ps, bool activate_on_start) {
 							if (ps->o.wm_class)
 								free(ps->o.wm_class);
 							ps->o.wm_class = str[i];
-							printfdf(true, "(): receiving new wm_class=%s",
+							printfdf(false, "(): receiving new wm_class=%s",
 									ps->o.wm_class);
 						}
 						if (param[i] & PIPEPRM_PIVOTING) {
 							ps->o.pivotkey = str[i][0];
-							printfdf(true, "(): receiving new pivot key=%d",ps->o.pivotkey);
+							printfdf(false, "(): receiving new pivot key=%d",ps->o.pivotkey);
 							toggling = false;
 						}
 					}
 
-					printfdf(true, "(): skippy activating: metaphor=%d", layout);
+					printfdf(false, "(): skippy activating: metaphor=%d", layout);
 				}
 				// parameter == 0, toggle
 				// otherwise shift window focus

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -29,16 +29,19 @@
 bool debuglog = false;
 
 enum pipe_cmd_t {
-	PIPECMD_EXIT_DAEMON = -1,
-	PIPECMD_RELOAD_CONFIG = 0,
-	PIPECMD_SWITCH = 1,
-	PIPECMD_EXPOSE,
-	PIPECMD_PAGING,
-	// these four are flags
-	PIPECMD_PREV = 4,
-	PIPECMD_NEXT = 8,
-	PIPECMD_PIVOTING = 16,
-	PIPECMD_WM_CLASS = 32,
+	PIPECMD_EXIT_DAEMON = 1,
+	PIPECMD_RELOAD_CONFIG = 2,
+	PIPECMD_SWITCH = 4,
+	PIPECMD_EXPOSE = 8,
+	PIPECMD_PAGING = 16,
+	PIPECMD_PREV = 32,
+	PIPECMD_NEXT = 64,
+	PIPECMD_MULTI_BYTE = 128,
+};
+
+enum pipe_param_t {
+	PIPEPRM_PIVOTING = 1,
+	PIPEPRM_WM_CLASS = 2,
 };
 
 session_t *ps_g = NULL;
@@ -266,9 +269,6 @@ parse_pictspec_end:
 	return true;
 }
 
-static char*
-receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd);
-
 static inline const char *
 ev_dumpstr_type(const XEvent *ev) {
 	switch (ev->type) {
@@ -367,6 +367,198 @@ ev_dump(session_t *ps, const MainWin *mw, const XEvent *ev) {
 
 	print_timestamp(ps);
 	printfdf(false, "(): Event %-13.13s wid %#010lx %s", name, wid, wextra);
+}
+
+static inline bool
+open_pipe(session_t *ps, struct pollfd *r_fd) {
+	if (ps->fd_pipe >= 0) {
+		close(ps->fd_pipe);
+		ps->fd_pipe = -1;
+		if (r_fd)
+			r_fd[1].fd = ps->fd_pipe;
+	}
+	ps->fd_pipe = open(ps->o.pipePath, O_RDONLY | O_NONBLOCK);
+	if (ps->fd_pipe >= 0) {
+		if (r_fd)
+			r_fd[1].fd = ps->fd_pipe;
+		return true;
+	}
+	else {
+		printfef(true, "(): Failed to open pipe \"%s\": %d", ps->o.pipePath, errno);
+		perror("open");
+	}
+
+	return false;
+}
+
+static inline int
+read_pipe(session_t *ps, struct pollfd *r_fd, char *piped_input) {
+	int read_ret = read(ps->fd_pipe, piped_input, 1);
+	if (0 == read_ret) {
+		printfef(true, "(): EOF reached on pipe \"%s\".", ps->o.pipePath);
+		open_pipe(ps, r_fd);
+	}
+	else if (-1 == read_ret) {
+		if (EAGAIN != errno)
+			printfef(true, "(): Reading pipe \"%s\" failed: %d", ps->o.pipePath, errno);
+		//exit(1);
+	}
+
+	assert(1 == read_ret);
+	return read_ret;
+}
+
+static void
+send_string_command_to_daemon_via_fifo(
+		const char *pipePath, char* command) {
+	{
+		int access_ret = 0;
+		if ((access_ret = access(pipePath, W_OK))) {
+			printfef(true, "(): Failed to access() pipe \"%s\": %d", pipePath, access_ret);
+			perror("access");
+			exit(1);
+		}
+	}
+
+	printfdf(true, "(): sending string command to pipe of length %d",
+			(int)strlen(command) + 1);
+
+	char final_cmd[strlen(command)+1];
+	sprintf(final_cmd, "%c%s", (char)strlen(command), command);
+	printfdf(true, "(): string command: %s", final_cmd);
+
+	int fp = open(pipePath, O_WRONLY);
+	int bytes_written = write(fp, final_cmd, strlen(command)+1);
+	if (bytes_written < strlen(command))
+		printfef(true, "(): incomplete command sent!");
+	close(fp);
+}
+
+static void
+send_command_to_daemon_via_fifo(char command, const char *pipePath) {
+	// single character command is NOT NULL terminated
+	char str[2];
+	sprintf(str, "%c", command);
+	send_string_command_to_daemon_via_fifo(pipePath, str);
+}
+
+static char
+receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
+		char *nparams, char **param, char ***str) {
+	char cmdlen = 0;
+	read_pipe(ps, r_fd, &cmdlen);
+	if (cmdlen <= 0) {
+		printfef(true, "(): stubbed command received");
+		exit(1);
+	}
+
+	char *buffer = malloc(cmdlen);
+	int ret_read = read(ps->fd_pipe, buffer, cmdlen);
+	if (ret_read < cmdlen) {
+		printfef(true, "(): stubbed command received");
+		exit(1);
+	}
+
+	char master_command = buffer[0];
+
+	if ((master_command & PIPECMD_MULTI_BYTE) == 0) {
+		printfdf(true, "(): received single byte command %d", master_command);
+		*nparams = 0;
+		param = NULL;
+		str = NULL;
+	}
+	else {
+		if (cmdlen <= 1) {
+			printfef(true, "(): multi-byte command stubbed");
+			exit(1);
+		}
+
+		*nparams = buffer[1];
+		printfdf(true, "(): received multi-byte command %d of %d bytes and %d parameters",
+				master_command, cmdlen, *nparams);
+		*param = malloc(*nparams * sizeof(char*));
+		*str = malloc(*nparams * sizeof(char*));
+
+		int k=2;
+		for (int i=0; i < *nparams; i++) {
+			*param[i] = buffer[k];
+			k++;
+
+			char nchar = buffer[k];
+			printfdf(true, "(): parameter %d takes %d bytes...",
+					*param[i], nchar);
+			k++;
+
+			*str[i] = malloc(nchar+1);
+			for (int j=0; j<nchar && buffer[k]!='\0'; j++) {
+				(*str[i])[j] = buffer[k];
+				k++;
+			}
+			(*str[i])[(int)nchar] = '\0';
+			k++;
+
+			printfdf(true, "(): received parameter %c%s", *param[i], *str[i]);
+		}
+	}
+	return master_command;
+}
+
+static inline void
+exit_daemon(const char *pipePath) {
+	printfdf(false, "(): Killing daemon...");
+	send_command_to_daemon_via_fifo(PIPECMD_EXIT_DAEMON, pipePath);
+}
+
+static inline void
+queue_reload_config(session_t *ps, const char *pipePath) {
+	char *config_path = "";
+	if (!ps->o.config_reload)
+		config_path = ps->o.config_path;
+
+	char command[256];
+	sprintf(command, "%c%c%s",
+			PIPECMD_RELOAD_CONFIG, (char)strlen(config_path), config_path);
+	send_string_command_to_daemon_via_fifo( pipePath, command);
+}
+
+static void
+activate_via_fifo(session_t *ps, const char *pipePath) {
+	char master_command = 0;
+	if (ps->o.mode == PROGMODE_SWITCH)
+		master_command |= PIPECMD_SWITCH;
+	if (ps->o.mode == PROGMODE_EXPOSE)
+		master_command |= PIPECMD_EXPOSE;
+	if (ps->o.mode == PROGMODE_PAGING)
+		master_command |= PIPECMD_PAGING;
+
+	if (ps->o.focus_initial > 0)
+		master_command |= PIPECMD_NEXT;
+	else if (ps->o.focus_initial < 0)
+		master_command |= PIPECMD_PREV;
+
+	char command[256];
+	char nparams = (ps->o.wm_class != NULL) + (ps->o.pivotkey != 0);
+	if (nparams > 0) {
+		master_command |= PIPECMD_MULTI_BYTE;
+		sprintf(command, "%c%c", master_command, nparams);
+	}
+	else
+		sprintf(command, "%c", master_command);
+
+	if (ps->o.pivotkey) {
+		char pivot_cmd[4];
+		sprintf(pivot_cmd, "%c%c%c", PIPEPRM_PIVOTING, 1, ps->o.pivotkey);
+		strcat(command, pivot_cmd);
+	}
+
+	if (ps->o.wm_class) {
+		char wm_cmd[1+1+strlen(ps->o.wm_class)+1];
+		sprintf(wm_cmd, "%c%c%s",
+				PIPEPRM_WM_CLASS, (char)strlen(ps->o.wm_class), ps->o.wm_class);
+		strcat(command, wm_cmd);
+	}
+
+	send_string_command_to_daemon_via_fifo(pipePath, command);
 }
 
 static void
@@ -916,60 +1108,6 @@ skippy_activate(MainWin *mw, enum layoutmode layout)
 	return true;
 }
 
-static inline bool
-open_pipe(session_t *ps, struct pollfd *r_fd) {
-	if (ps->fd_pipe >= 0) {
-		close(ps->fd_pipe);
-		ps->fd_pipe = -1;
-		if (r_fd)
-			r_fd[1].fd = ps->fd_pipe;
-	}
-	ps->fd_pipe = open(ps->o.pipePath, O_RDONLY | O_NONBLOCK);
-	if (ps->fd_pipe >= 0) {
-		if (r_fd)
-			r_fd[1].fd = ps->fd_pipe;
-		return true;
-	}
-	else {
-		printfef(true, "(): Failed to open pipe \"%s\": %d", ps->o.pipePath, errno);
-		perror("open");
-	}
-
-	return false;
-}
-
-static inline int
-read_pipe(session_t *ps, struct pollfd *r_fd, char *piped_input) {
-	int read_ret = read(ps->fd_pipe, piped_input, 1);
-	if (0 == read_ret) {
-		printfef(true, "(): EOF reached on pipe \"%s\".", ps->o.pipePath);
-		open_pipe(ps, r_fd);
-	}
-	else if (-1 == read_ret) {
-		if (EAGAIN != errno)
-			printfef(true, "(): Reading pipe \"%s\" failed: %d", ps->o.pipePath, errno);
-		//exit(1);
-	}
-
-	assert(1 == read_ret);
-	return read_ret;
-}
-
-static bool
-pivoting(session_t *ps, KeyCode *keycodes) {
-	bool result = false;
-	char keys[32];
-	XQueryKeymap(ps->dpy, keys);
-
-	for (int i=0; keycodes[i] != 0x00; i++) {
-		int slot = keycodes[i] / 8;
-		char mask = 1 << (keycodes[i] % 8);
-		result = result || (keys[slot] & mask);
-	}
-
-	return result;
-}
-
 static void
 mainloop(session_t *ps, bool activate_on_start) {
 	MainWin *mw = NULL;
@@ -1106,16 +1244,12 @@ mainloop(session_t *ps, bool activate_on_start) {
 		if (mw && !toggling)
 		{
 			bool pivotTerminate = false;
-			if (layout == LAYOUTMODE_SWITCH && mw->keycodes_PivotSwitch) {
-				pivotTerminate = !pivoting(ps, mw->keycodes_PivotSwitch);
-			}
-			else if (layout == LAYOUTMODE_EXPOSE && mw->keycodes_PivotExpose) {
-				pivotTerminate = !pivoting(ps, mw->keycodes_PivotExpose);
-			}
-			else if (layout == LAYOUTMODE_PAGING && mw->keycodes_PivotPaging) {
-				pivotTerminate = !pivoting(ps, mw->keycodes_PivotPaging);
-			}
-			
+			char keys[32];
+			XQueryKeymap(ps->dpy, keys);
+			int slot = ps->o.pivotkey / 8;
+			char mask = 1 << (ps->o.pivotkey % 8);
+			pivotTerminate = !(keys[slot] & mask);
+
 			if (pivotTerminate) {
 				die = true;
 				ps->o.focus_initial = 0;
@@ -1382,89 +1516,94 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 		// Handle daemon commands
 		if (POLLIN & r_fd[1].revents) {
-			char piped_input;
-			read_pipe(ps, r_fd, &piped_input);
+			char nparams=0, *param=0, **str=0;
+			char piped_input = receive_string_in_daemon_via_fifo(ps, r_fd,
+					&nparams, &param, &str);
 			printfdf(false, "(): Received pipe command: %d", piped_input);
 
-			switch (piped_input) {
-				case PIPECMD_RELOAD_CONFIG:
-					char *config_path = receive_string_in_daemon_via_fifo(ps, r_fd);
-					if (strlen(config_path) > 0) {
+			if (piped_input & PIPECMD_EXIT_DAEMON) {
+				printfdf(false, "(): Exit command received, killing daemon...");
+				unlink(ps->o.pipePath);
+				return;
+			}
+			else if (piped_input & PIPECMD_RELOAD_CONFIG) {
+				for (int i=0; i<nparams; i++) {
+					if (param[i] == PIPECMD_RELOAD_CONFIG) {
 						if (ps->o.config_path)
 							free(ps->o.config_path);
-						ps->o.config_path = config_path;
+						ps->o.config_path = str[i];
 					}
-					load_config_file(ps);
-					mainwin_reload(ps, ps->mainwin);
-					break;
-				case PIPECMD_EXIT_DAEMON:
-					printfdf(false, "(): Exit command received, killing daemon...");
-					unlink(ps->o.pipePath);
-					return;
-				default:
-					ps->o.focus_initial = -((piped_input & PIPECMD_PREV) > 0)
-						+ ((piped_input & PIPECMD_NEXT) > 0);
+				}
+			}
+			else {
+				ps->o.focus_initial = -((piped_input & PIPECMD_PREV) > 0)
+					+ ((piped_input & PIPECMD_NEXT) > 0);
 
-					if (!mw || !mw->mapped)
-					{
-						animating = activate = true;
-						if ((piped_input & PIPECMD_PAGING) == PIPECMD_PAGING) {
-							ps->o.mode = PROGMODE_PAGING;
-							layout = LAYOUTMODE_PAGING;
-						}
-						else if ((piped_input & PIPECMD_EXPOSE) == PIPECMD_EXPOSE) {
-							ps->o.mode = PROGMODE_EXPOSE;
-							layout = LAYOUTMODE_EXPOSE;
-						}
-						else if ((piped_input & PIPECMD_SWITCH) == PIPECMD_SWITCH) {
-							ps->o.mode = PROGMODE_SWITCH;
-							layout = LAYOUTMODE_SWITCH;
-						}
+				if (!mw || !mw->mapped)
+				{
+					animating = activate = true;
+					if (piped_input & PIPECMD_SWITCH) {
+						ps->o.mode = PROGMODE_SWITCH;
+						layout = LAYOUTMODE_SWITCH;
+					}
+					if (piped_input & PIPECMD_EXPOSE) {
+						ps->o.mode = PROGMODE_EXPOSE;
+						layout = LAYOUTMODE_EXPOSE;
+					}
+					if (piped_input & PIPECMD_PAGING) {
+						ps->o.mode = PROGMODE_PAGING;
+						layout = LAYOUTMODE_PAGING;
+					}
 
-						if (!ps->o.persistentFiltering && ps->o.wm_class) {
-							free(ps->o.wm_class);
-							ps->o.wm_class = NULL;
-						}
+					if (!ps->o.persistentFiltering && ps->o.wm_class) {
+						free(ps->o.wm_class);
+						ps->o.wm_class = NULL;
+					}
 
-						if (piped_input & PIPECMD_WM_CLASS) {
+					toggling = true;
+					for (int i=0; i<nparams; i++) {
+						if (param[i] & PIPEPRM_WM_CLASS) {
 							if (ps->o.wm_class)
 								free(ps->o.wm_class);
-							ps->o.wm_class = receive_string_in_daemon_via_fifo(
-									ps, r_fd);
-							printfdf(false, "(): receiving newwm_class=%s",
+							ps->o.wm_class = str[i];
+							printfdf(true, "(): receiving new wm_class=%s",
 									ps->o.wm_class);
 						}
-
-						toggling = !(piped_input & PIPECMD_PIVOTING);
-						printfdf(false, "(): skippy activating, mode=%d", layout);
-					}
-					// parameter == 0, toggle
-					// otherwise shift window focus
-					else if (mw && ps->o.focus_initial == 0) {
-						if (toggling) {
-							printfdf(false, "(): toggling skippy off");
-							mw->refocus = die = true;
+						if (param[i] & PIPEPRM_PIVOTING) {
+							ps->o.pivotkey = str[i][0];
+							printfdf(true, "(): receiving new pivot key=%d",ps->o.pivotkey);
+							toggling = false;
 						}
-
-						break;
 					}
-					else if (mw && mw->mapped)
-					{
-						printfdf(false, "(): cycling window");
-						fflush(stdout);fflush(stderr);
 
-						if (ps->o.focus_initial < 0)
-							ps->o.focus_initial = dlist_len(mw->focuslist) + ps->o.focus_initial;
-
-						while (ps->o.focus_initial > 0 && mw->client_to_focus) {
-							focus_miniw_next(ps, mw->client_to_focus);
-							ps->o.focus_initial--;
-						}
-
-						if (mw->client_to_focus)
-							clientwin_render(mw->client_to_focus);
+					printfdf(true, "(): skippy activating: metaphor=%d", layout);
+				}
+				// parameter == 0, toggle
+				// otherwise shift window focus
+				else if (mw && ps->o.focus_initial == 0) {
+					if (toggling) {
+						printfdf(false, "(): toggling skippy off");
+						mw->refocus = die = true;
 					}
+
 					break;
+				}
+				else if (mw && mw->mapped)
+				{
+					printfdf(false, "(): cycling window");
+					fflush(stdout);fflush(stderr);
+
+					if (ps->o.focus_initial < 0)
+						ps->o.focus_initial = dlist_len(mw->focuslist) + ps->o.focus_initial;
+
+					while (ps->o.focus_initial > 0 && mw->client_to_focus) {
+						focus_miniw_next(ps, mw->client_to_focus);
+						ps->o.focus_initial--;
+					}
+
+					if (mw->client_to_focus)
+						clientwin_render(mw->client_to_focus);
+				}
 			}
 		}
 
@@ -1473,151 +1612,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 			open_pipe(ps, r_fd);
 		}
 	}
-}
-
-static void
-send_command_to_daemon_via_fifo(int command, const char *pipePath) {
-	{
-		int access_ret = 0;
-		if ((access_ret = access(pipePath, W_OK))) {
-			printfef(true, "(): Failed to access() pipe \"%s\": %d", pipePath, access_ret);
-			perror("access");
-			exit(1);
-		}
-	}
-
-	FILE *fp = fopen(pipePath, "w");
-
-	printfdf(false, "(): Sending command...");
-	fputc(command, fp);
-
-	fclose(fp);
-}
-
-static void
-send_string_command_to_daemon_via_fifo(int command, char *str, const char *pipePath) {
-	{
-		int access_ret = 0;
-		if ((access_ret = access(pipePath, W_OK))) {
-			printfef(true, "(): Failed to access() pipe \"%s\": %d", pipePath, access_ret);
-			perror("access");
-			exit(1);
-		}
-	}
-
-	FILE *fp = fopen(pipePath, "a");
-	fputc(command, fp);
-
-	unsigned int strlen = 0;
-	for (int i=0; str[i] != '\0'; i++)
-		strlen++;
-	strlen++; // +1 for null terminator
-	if (strlen >= BUF_LEN)
-		printfef(true, "(): string length exceeds character limit. Aborting");
-
-	printfdf(false, "(): Sending string...");
-	fputc(strlen, fp);
-	for (int i=0; str[i] != '\0'; i++)
-		fputc(str[i], fp);
-	fputc('\0', fp);
-
-	fclose(fp);
-}
-
-static char*
-receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd) {
-	char strlen = 0;
-	read_pipe(ps, r_fd, &strlen);
-
-	char *str = malloc(strlen);
-
-	int read_ret = read(ps->fd_pipe, str, strlen);
-
-	if (0 == read_ret) {
-		printfef(true, "(): EOF reached on pipe \"%s\".", ps->o.pipePath);
-	}
-	else if (-1 == read_ret) {
-		if (EAGAIN != errno)
-			printfef(true, "(): Reading pipe \"%s\" failed: %d", ps->o.pipePath, errno);
-		//exit(1);
-	}
-
-	str[strlen-1] = '\0';
-
-	printfdf(false, "(): received string %s", str);
-	return str;
-}
-
-static inline void
-queue_reload_config(session_t *ps, const char *pipePath) {
-	char *config_path = "";
-	if (!ps->o.config_reload)
-		config_path = ps->o.config_path;
-	send_string_command_to_daemon_via_fifo(PIPECMD_RELOAD_CONFIG, config_path, pipePath);
-}
-
-static inline void
-exit_daemon(const char *pipePath) {
-	printfdf(false, "(): Killing daemon...");
-	send_command_to_daemon_via_fifo(PIPECMD_EXIT_DAEMON, pipePath);
-}
-
-static inline char
-char2pipe(char focus_initial) {
-	char res = 0;
-	if (focus_initial > 0)
-	   res = PIPECMD_NEXT;
-	else if (focus_initial < 0)
-		res = PIPECMD_PREV;
-	return res;
-}
-
-static inline void
-activate_switch(session_t *ps, const char *pipePath) {
-	printfdf(false, "(): Activating switch...");
-	if (ps->o.wm_class)
-		send_string_command_to_daemon_via_fifo(
-				PIPECMD_SWITCH
-				| PIPECMD_WM_CLASS
-				| (ps->o.pivoting? PIPECMD_PIVOTING: 0),
-				ps->o.wm_class, pipePath);
-	else
-		send_command_to_daemon_via_fifo(PIPECMD_SWITCH
-				| char2pipe(ps->o.focus_initial)
-				| (ps->o.pivoting? PIPECMD_PIVOTING: 0),
-				pipePath);
-}
-
-static inline void
-activate_expose(session_t *ps, const char *pipePath) {
-	printfdf(false, "(): Activating expose...");
-	if (ps->o.wm_class)
-		send_string_command_to_daemon_via_fifo(
-				PIPECMD_EXPOSE
-				| PIPECMD_WM_CLASS
-				| (ps->o.pivoting? PIPECMD_PIVOTING: 0),
-				ps->o.wm_class, pipePath);
-	else
-		send_command_to_daemon_via_fifo(PIPECMD_EXPOSE
-				| char2pipe(ps->o.focus_initial)
-				| (ps->o.pivoting? PIPECMD_PIVOTING: 0),
-				pipePath);
-}
-
-static inline void
-activate_paging(session_t *ps, const char *pipePath) {
-	printfdf(false, "(): Activating paging...");
-	if (ps->o.wm_class)
-		send_string_command_to_daemon_via_fifo(
-				PIPECMD_PAGING
-				| PIPECMD_WM_CLASS
-				| (ps->o.pivoting? PIPECMD_PIVOTING: 0),
-				ps->o.wm_class, pipePath);
-	else
-		send_command_to_daemon_via_fifo(PIPECMD_PAGING
-				| char2pipe(ps->o.focus_initial)
-				| (ps->o.pivoting? PIPECMD_PIVOTING: 0),
-				pipePath);
 }
 
 /**
@@ -1713,7 +1707,7 @@ show_help() {
 			"\n"
 			"  --wm-class          - displays only windows of specific class.\n"
 			"\n"
-			"  --pivot             - activates via pivot mode, as opposed to toggling mode.\n"
+			"  --pivot             - activates via pivot mode with specified pivot key.\n"
 			"\n"
 			"  --prev              - focus on the previous window.\n"
 			"  --next              - focus on the next window.\n"
@@ -1866,7 +1860,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 		{ "start-daemon",             no_argument,       NULL, OPT_DM_START },
 		{ "stop-daemon",              no_argument,       NULL, OPT_DM_STOP },
 		{ "wm-class",                 required_argument, NULL, OPT_WM_CLASS },
-		{ "pivot",                    no_argument,       NULL, OPT_PIVOTING },
+		{ "pivot",                    required_argument, NULL, OPT_PIVOTING },
 		{ "prev",                     no_argument,       NULL, OPT_PREV },
 		{ "next",                     no_argument,       NULL, OPT_NEXT },
 		// { "test",                     no_argument,       NULL, 't' },
@@ -1934,7 +1928,13 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 				ps->o.wm_class = mstrdup(optarg);
 				break;
 			case OPT_PIVOTING:
-				ps->o.pivoting = true;
+				KeySym keysym = XStringToKeysym(optarg);
+				if (keysym == 0) {
+					printfef(true, "(): \"%s\" was not recognized as a valid KeySym. Run the program 'xev' to find the correct value.", optarg);
+					exit(1);
+				}
+
+				ps->o.pivotkey = XKeysymToKeycode(ps->dpy, keysym);
 				break;
 			case OPT_PREV:
 				ps->o.focus_initial--;
@@ -1946,7 +1946,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 				ps->o.runAsDaemon = true;
 				break;
 			default:
-				printfef(false, "(0): Unimplemented option %d.", o);
+				printfef(true, "(0): Unimplemented option %d.", o);
 				exit(RET_UNKNOWN);
 		}
 	}
@@ -2049,9 +2049,6 @@ load_config_file(session_t *ps)
     ps->o.bindings_keysIconify = mstrdup(config_get(config, "bindings", "keysIconify", "1"));
     ps->o.bindings_keysShade = mstrdup(config_get(config, "bindings", "keysShade", "2"));
     ps->o.bindings_keysClose = mstrdup(config_get(config, "bindings", "keysClose", "3"));
-    ps->o.bindings_keysPivotSwitch = mstrdup(config_get(config, "bindings", "keysPivotSwitch", "Alt_L"));
-    ps->o.bindings_keysPivotExpose = mstrdup(config_get(config, "bindings", "keysPivotExpose", ""));
-    ps->o.bindings_keysPivotPaging = mstrdup(config_get(config, "bindings", "keysPivotPaging", ""));
 
     // print an error message for any key bindings that aren't recognized
     check_keysyms(ps->o.config_path, ": [bindings] keysUp =", ps->o.bindings_keysUp);
@@ -2065,9 +2062,6 @@ load_config_file(session_t *ps)
     check_keysyms(ps->o.config_path, ": [bindings] keysIconify =", ps->o.bindings_keysIconify);
     check_keysyms(ps->o.config_path, ": [bindings] keysShade =", ps->o.bindings_keysShade);
     check_keysyms(ps->o.config_path, ": [bindings] keysClose =", ps->o.bindings_keysClose);
-    check_keysyms(ps->o.config_path, ": [bindings] keysPivotSwitch =", ps->o.bindings_keysPivotSwitch);
-    check_keysyms(ps->o.config_path, ": [bindings] keysPivotExpose =", ps->o.bindings_keysPivotExpose);
-    check_keysyms(ps->o.config_path, ": [bindings] keysPivotPaging =", ps->o.bindings_keysPivotPaging);
 
 	if (!parse_cliop(ps, config_get(config, "bindings", "miwMouse1", "focus"), &ps->o.bindings_miwMouse[1])
 			|| !parse_cliop(ps, config_get(config, "bindings", "miwMouse2", "close-ewmh"), &ps->o.bindings_miwMouse[2])
@@ -2258,20 +2252,17 @@ int main(int argc, char *argv[]) {
 	switch (ps->o.mode) {
 		case PROGMODE_NORMAL:
 			break;
-		case PROGMODE_SWITCH:
-			activate_switch(ps, pipePath);
-			goto main_end;
-		case PROGMODE_EXPOSE:
-			activate_expose(ps, pipePath);
-			goto main_end;
-		case PROGMODE_PAGING:
-			activate_paging(ps, pipePath);
+		case PROGMODE_DM_STOP:
+			exit_daemon(pipePath);
 			goto main_end;
 		case PROGMODE_RELOAD_CONFIG:
 			queue_reload_config(ps, pipePath);
 			goto main_end;
-		case PROGMODE_DM_STOP:
-			exit_daemon(pipePath);
+		default:
+			// this is switch/expose/paging
+			// potentially with flags of prev/next
+			// or multi-byte pipe command
+			activate_via_fifo(ps, pipePath);
 			goto main_end;
 	}
 
@@ -2366,12 +2357,9 @@ main_end:
 			free(ps->o.bindings_keysIconify);
 			free(ps->o.bindings_keysShade);
 			free(ps->o.bindings_keysClose);
-			free(ps->o.bindings_keysPivotSwitch);
-			free(ps->o.bindings_keysPivotExpose);
-			free(ps->o.bindings_keysPivotPaging);
 		}
 
-		if(ps->o.wm_class)
+		if (ps->o.wm_class)
 			free(ps->o.wm_class);
 
 		if (ps->fd_pipe >= 0)

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1592,8 +1592,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 						printfdf(false, "(): toggling skippy off");
 						mw->refocus = die = true;
 					}
-
-					break;
 				}
 				else if (mw && mw->mapped)
 				{

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1877,6 +1877,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 	optind = 1;
 	bool custom_config = false;
 	bool config_reload = false;
+	bool user_specified_toggle_pivot = false;
 
 	// Only parse --config in first pass
 	if (first_pass) {
@@ -1934,9 +1935,11 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 				ps->o.wm_class = mstrdup(optarg);
 				break;
 			case OPT_TOGGLE:
+				user_specified_toggle_pivot = true;
 				ps->o.pivotkey = 0;
 				break;
 			case OPT_PIVOTING:
+				user_specified_toggle_pivot = true;
 				KeySym keysym = XStringToKeysym(optarg);
 				if (keysym == 0) {
 					printfef(true, "(): \"%s\" was not recognized as a valid KeySym. Run the program 'xev' to find the correct value.", optarg);
@@ -1957,6 +1960,16 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 			default:
 				printfef(true, "(0): Unimplemented option %d.", o);
 				exit(RET_UNKNOWN);
+		}
+	}
+
+	if (!user_specified_toggle_pivot) {
+		if (ps->o.mode == PROGMODE_SWITCH) {
+			ps->o.pivotkey = 64; // switch defaults to pivot with Alt_L
+		}
+		if (ps->o.mode == PROGMODE_EXPOSE
+				|| ps->o.mode == PROGMODE_PAGING) {
+			ps->o.pivotkey = 0; // expose/paging defaults to toggle
 		}
 	}
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1696,7 +1696,7 @@ show_help() {
 			"  [no command]        - activate expose once without daemon.\n"
 			"\n"
 			"  --help              - show this message.\n"
-			"  --debuglog          - enable debugging logs.\n"
+			"  --debug-log          - enable debugging logs.\n"
 			"\n"
 			"  --config            - load/reload configuration file from specifed path.\n"
 			"  --config-reload     - reload configuration file without changing path.\n"
@@ -1855,7 +1855,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 	static const char * opts_short = "h";
 	static const struct option opts_long[] = {
 		{ "help",                     no_argument,       NULL, 'h' },
-		{ "debuglog",                 no_argument,       NULL, OPT_DEBUGLOG },
+		{ "debug-log",                no_argument,       NULL, OPT_DEBUGLOG },
 		{ "config",                   required_argument, NULL, OPT_CONFIG },
 		{ "config-reload",            no_argument,       NULL, OPT_CONFIG_RELOAD },
 		{ "switch",                   no_argument,       NULL, OPT_ACTV_SWITCH },

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -474,6 +474,7 @@ receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 		}
 
 		*nparams = buffer[1];
+		printfdf(true, "(): full command %s", buffer);
 		printfdf(true, "(): received multi-byte command %d of %d bytes and %d parameters",
 				master_command, cmdlen, *nparams);
 		*param = malloc(*nparams * sizeof(char*));
@@ -481,23 +482,20 @@ receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 
 		int k=2;
 		for (int i=0; i < *nparams; i++) {
-			*param[i] = buffer[k];
+			(*param)[i] = buffer[k];
 			k++;
 
 			char nchar = buffer[k];
 			printfdf(true, "(): parameter %d takes %d bytes...",
-					*param[i], nchar);
+					(*param)[i], nchar);
 			k++;
 
-			*str[i] = malloc(nchar+1);
-			for (int j=0; j<nchar && buffer[k]!='\0'; j++) {
-				(*str[i])[j] = buffer[k];
-				k++;
-			}
-			(*str[i])[(int)nchar] = '\0';
-			k++;
+			(*str)[i] = malloc(nchar+1);
+			strncpy((*str)[i], buffer + k, nchar);
+			(*str)[i][(int)nchar] = '\0';
+			k += nchar;
 
-			printfdf(true, "(): received parameter %c%s", *param[i], *str[i]);
+			printfdf(true, "(): received parameter %d%s", (*param)[i], (*str)[i]);
 		}
 	}
 	return master_command;
@@ -557,7 +555,6 @@ activate_via_fifo(session_t *ps, const char *pipePath) {
 				PIPEPRM_WM_CLASS, (char)strlen(ps->o.wm_class), ps->o.wm_class);
 		strcat(command, wm_cmd);
 	}
-
 	send_string_command_to_daemon_via_fifo(pipePath, command);
 }
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1710,6 +1710,7 @@ show_help() {
 			"\n"
 			"  --wm-class          - displays only windows of specific class.\n"
 			"\n"
+			"  --toggle            - activates via toggle mode.\n"
 			"  --pivot             - activates via pivot mode with specified pivot key.\n"
 			"\n"
 			"  --prev              - focus on the previous window.\n"
@@ -1847,6 +1848,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 		OPT_DM_START,
 		OPT_DM_STOP,
 		OPT_WM_CLASS,
+		OPT_TOGGLE,
 		OPT_PIVOTING,
 		OPT_PREV,
 		OPT_NEXT,
@@ -1863,6 +1865,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 		{ "start-daemon",             no_argument,       NULL, OPT_DM_START },
 		{ "stop-daemon",              no_argument,       NULL, OPT_DM_STOP },
 		{ "wm-class",                 required_argument, NULL, OPT_WM_CLASS },
+		{ "toggle",                   no_argument,       NULL, OPT_TOGGLE },
 		{ "pivot",                    required_argument, NULL, OPT_PIVOTING },
 		{ "prev",                     no_argument,       NULL, OPT_PREV },
 		{ "next",                     no_argument,       NULL, OPT_NEXT },
@@ -1929,6 +1932,9 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 				break;
 			case OPT_WM_CLASS:
 				ps->o.wm_class = mstrdup(optarg);
+				break;
+			case OPT_TOGGLE:
+				ps->o.pivotkey = 0;
 				break;
 			case OPT_PIVOTING:
 				KeySym keysym = XStringToKeysym(optarg);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1898,7 +1898,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 					custom_config = true;
 					if (ps->o.config_path)
 						free(ps->o.config_path);
-					ps->o.config_path = mstrdup(optarg);
+					ps->o.config_path = realpath(optarg, NULL);
 					break;
 				case OPT_CONFIG_RELOAD:
 					config_reload = true;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -514,9 +514,11 @@ queue_reload_config(session_t *ps, const char *pipePath) {
 		config_path = ps->o.config_path;
 
 	char command[256];
-	sprintf(command, "%c%c%s",
-			PIPECMD_RELOAD_CONFIG, (char)strlen(config_path), config_path);
-	send_string_command_to_daemon_via_fifo( pipePath, command);
+	sprintf(command, "%c%c%c%c%s",
+			PIPECMD_RELOAD_CONFIG | PIPECMD_MULTI_BYTE,
+			1, PIPECMD_RELOAD_CONFIG,
+			(char)strlen(config_path), config_path);
+	send_string_command_to_daemon_via_fifo(pipePath, command);
 }
 
 static void
@@ -1529,6 +1531,8 @@ mainloop(session_t *ps, bool activate_on_start) {
 						if (ps->o.config_path)
 							free(ps->o.config_path);
 						ps->o.config_path = str[i];
+						load_config_file(ps);
+						mainwin_reload(ps, ps->mainwin);
 					}
 				}
 			}

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1536,7 +1536,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 					if (param[i] == PIPECMD_RELOAD_CONFIG) {
 						if (ps->o.config_path)
 							free(ps->o.config_path);
-						ps->o.config_path = str[i];
+						ps->o.config_path = mstrdup(str[i]);
 					}
 				}
 				load_config_file(ps);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -509,16 +509,19 @@ exit_daemon(const char *pipePath) {
 
 static inline void
 queue_reload_config(session_t *ps, const char *pipePath) {
-	char *config_path = "";
-	if (!ps->o.config_reload)
-		config_path = ps->o.config_path;
-
-	char command[256];
-	sprintf(command, "%c%c%c%c%s",
-			PIPECMD_RELOAD_CONFIG | PIPECMD_MULTI_BYTE,
-			1, PIPECMD_RELOAD_CONFIG,
-			(char)strlen(config_path), config_path);
-	send_string_command_to_daemon_via_fifo(pipePath, command);
+	if (!ps->o.config_reload) {
+		char command[256];
+		sprintf(command, "%c%c%c%c%s",
+				PIPECMD_RELOAD_CONFIG | PIPECMD_MULTI_BYTE,
+				1, PIPECMD_RELOAD_CONFIG,
+				(char)strlen(ps->o.config_path), ps->o.config_path);
+		send_string_command_to_daemon_via_fifo(pipePath, command);
+	}
+	else {
+		char command[256];
+		sprintf(command, "%c", PIPECMD_RELOAD_CONFIG);
+		send_string_command_to_daemon_via_fifo(pipePath, command);
+	}
 }
 
 static void
@@ -1531,10 +1534,10 @@ mainloop(session_t *ps, bool activate_on_start) {
 						if (ps->o.config_path)
 							free(ps->o.config_path);
 						ps->o.config_path = str[i];
-						load_config_file(ps);
-						mainwin_reload(ps, ps->mainwin);
 					}
 				}
+				load_config_file(ps);
+				mainwin_reload(ps, ps->mainwin);
 			}
 			else {
 				ps->o.focus_initial = -((piped_input & PIPECMD_PREV) > 0)

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1572,7 +1572,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 						if (param[i] & PIPEPRM_WM_CLASS) {
 							if (ps->o.wm_class)
 								free(ps->o.wm_class);
-							ps->o.wm_class = str[i];
+							ps->o.wm_class = mstrdup(str[i]);
 							printfdf(false, "(): receiving new wm_class=%s",
 									ps->o.wm_class);
 						}
@@ -1617,6 +1617,8 @@ mainloop(session_t *ps, bool activate_on_start) {
 			for (int i=0; i<nparams; i++)
 				if (str[i])
 					free(str[i]);
+			if (str)
+				free(str);
 		}
 
 		if (POLLHUP & r_fd[1].revents) {

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -192,8 +192,8 @@ typedef struct {
 	bool config_reload;
 	enum progmode mode;
 	bool runAsDaemon;
-	bool pivoting;
 	char focus_initial;
+	KeyCode pivotkey;
 
 	int exposeLayout;
 	int distance;
@@ -267,9 +267,6 @@ typedef struct {
 	char *bindings_keysIconify;
 	char *bindings_keysShade;
 	char *bindings_keysClose;
-	char *bindings_keysPivotSwitch;
-	char *bindings_keysPivotExpose;
-	char *bindings_keysPivotPaging;
 } options_t;
 
 #define OPTIONST_INIT { \
@@ -277,7 +274,7 @@ typedef struct {
 	.config_reload = false, \
 	.mode = PROGMODE_NORMAL, \
 	.runAsDaemon = false, \
-	.pivoting = false, \
+	.pivotkey = 0, \
 \
 	.exposeLayout = LAYOUT_BOXY, \
 	.distance = 50, \

--- a/src/wm.c
+++ b/src/wm.c
@@ -690,7 +690,9 @@ wm_validate_window(session_t *ps, Window wid) {
 				result = false;
 			XFree(hints->res_name);
 			XFree(hints->res_class);
+			XFree(hints);
 		}
+		regfree(&regex);
 	}
 
 	return result;


### PR DESCRIPTION
This is a big PR with one commit with the intention of following:

Recent work has revamped the pipe protocol, extending each client-to-server command from single byte to allow for multiple bytes. This allowed loading config file in a new path, as well as window class filtering.

With this protocol change, I realized I could change the current pivot key specification from the config file to the command-line parameter. In other words, the pivot key would not be specified in these configs:
```
keysPivotSwitch = Alt_L
keysPivotExpose = 
keysPivotPaging = 
```

Rather, the user would specify the pivot key in the command line parameter like so:
```
skippy-xd --switch --pivot Alt_L --next
```

There are pros and cons with these two interfaces:
Pivot key location | Example command | Pros | Cons
--- | --- | --- | ---
Config | skippy-xd --switch --pivot --next | Shorter command | Interface split between command line and config file, leading to potential confusion
Cmd-line | skippy-xd --switch --pivot Alt_L --next | Command is 100% self contained | Long command

And example `.xbindkeysrc` with the old vs new syntax:
```
"skippy-xd --switch --pivot --next"
  Alt + Tab

"skippy-xd --switch --pivot --prev"
  Alt + Shift + Tab

"skippy-xd --expose"
  Super_L

"skippy-xd --paging"
  Super_R
```

```
"skippy-xd --switch --pivot Alt_L --next"
  Alt + Tab

"skippy-xd --switch --pivot Alt_L --prev"
  Alt + Shift + Tab

"skippy-xd --expose"
  Super_L

"skippy-xd --paging"
  Super_R
```

And my personal favourite:

```
"skippy-xd --switch --pivot Alt_L --next"
  Alt + Tab

"skippy-xd --switch --pivot Alt_L --prev"
  Alt + Shift + Tab

"skippy-xd --expose --pivot Super_L"
  Super_L

"skippy-xd --paging --pivot Super_R"
  Super_R
```

I feel with the new syntax, despite being longer and less readable, makes the intent of the pivot key more explicit, and user config error much less likely. Hence it is overall superior.

The implementation is to parse the pivot key from client to daemon via named pipe.

With this new specification, a problem arises: the user can invoke skippy-xd with window class filtering like this:
```
skippy-xd --switch --pivot Alt_L --next --wm-class XTerm
```

Then, in one command, there are two sub-parameters: the pivot key, and the window class filtering. Current implementation only allows one sub-parameter.

Hence, this PR not only implement parsing pivot key from client to daemon. This PR also redesigns the pipe command protocol, the implementation is concretized in receive_string_in_daemon_via_fifo():

```
[whole command byte length] [master command] [number of parameters] [parameter ] [parameter byte length] [parameter string] [parameter] [parameter byte length] [parameter string] ...
```