### PR TITLE
Physics based expose layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 
 CPPFLAGS += -std=c99 -Wall -I/usr/include/freetype2
 
-SRCS_RAW = skippy wm dlist mainwin clientwin layout focus config tooltip img img-xlib
+SRCS_RAW = skippy wm dlist mainwin clientwin physics layout focus config tooltip img img-xlib
 PACKAGES = x11 xft xrender xcomposite xdamage xfixes
 
 # === Options ===

--- a/src/layout.c
+++ b/src/layout.c
@@ -187,52 +187,26 @@ newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
 	if (!isIntersecting(cw1, cw2))
 		return;
 
-	{
-		int x1=0, y1=0;
-		com(cw1, &x1, &y1);
-		int x2=0, y2=0;
-		com(cw2, &x2, &y2);
-
-		// if two windows have the same centre of mass,
-		// move in random direction
-		if (x1 == x2 && y1 == y2) {
-			*newx = x1 + rand() % 50;
-			*newy = y1 + rand() % 50;
-			return;
-		}
-	}
+    int x1=0, y1=0;
+    com(cw1, &x1, &y1);
+    int x2=0, y2=0;
+    com(cw2, &x2, &y2);
 
 	// if two windows have the same centre of mass,
 	// move in random direction
-	{
-		int x1=0, y1=0;
-		com(cw1, &x1, &y1);
-		int x2=0, y2=0;
-		com(cw2, &x2, &y2);
-
-		if (x1 == x2 && y1 == y2) {
-			*newx = x1 + rand() % 50;
-			*newy = y1 + rand() % 50;
-			return;
-		}
+	if (x1 == x2 && y1 == y2) {
+		*newx = x1 + rand() % 50;
+		*newy = y1 + rand() % 50;
+		return;
 	}
 
-	// basic rectangular collision reflection
-	int dis = cw1->mainwin->distance / 2;
-	int x1 = cw1->x, x2 = cw2->x;
-	int y1 = cw1->y, y2 = cw2->y;
-	int w1 = cw1->src.width, w2 = cw2->src.width;
-	int h1 = cw1->src.height, h2 = cw2->src.height;
-
-	if (x2 - dis <= x1 && x1 < x2 + w2 + dis)
-		*newx = x2 + w2 + dis;
-	else if (x1 - dis <= x2 && x2 < x1 + w1 + dis)
-		*newx = x2 - w1 - dis;
-
-	if (y2 - dis <= y1 && y1 < y2 + h2 + dis)
-		*newy = y2 + h2 + dis;
-	else if (y1 - dis >= y2 && y2 < y1 + h1 + dis)
-		*newy = y2 - h1 - dis;
+	int dx = x1 - x2;
+	int dy = y1 - y2;
+	float norm = sqrt((float)(dx*dx + dy*dy));
+	dx = (float)dx / (float)norm * 50.0;
+	dy = (float)dy / (float)norm * 50.0;
+	*newx = cw1->x + dx;
+	*newy = cw1->y + dy;
 }
 
 void

--- a/src/layout.c
+++ b/src/layout.c
@@ -181,7 +181,7 @@ layout_boxy(MainWin *mw, dlist *windows,
 	float expansion_coefficient = 1.1;
 
 	int iterations = 0;
-	bool colliding = true;
+	bool colliding = true, stuck = false;
 	while (true) {
 		int minx = INT_MAX, maxx = INT_MIN;
 		int miny = INT_MAX, maxy = INT_MIN;
@@ -218,18 +218,22 @@ layout_boxy(MainWin *mw, dlist *windows,
 		// this is of course O(n^2) complexity
 		dlist_sort(windows, sort_cw_by_id, 0);
 		dlist_sort(windows, sort_cw_by_column, 0);
+		if (stuck)
+			dlist_reverse(windows);
+		stuck = true;
 
 		for (dlist *iter1 = dlist_first(windows)->next;
 				iter1; iter1=iter1->next) {
+			ClientWin *cw1 = iter1->data;
+			int oldx = cw1->x;
+			int oldy = cw1->y;
 			for (dlist *iter2 = dlist_first(windows);
 					iter2 != iter1; iter2=iter2->next) {
-				ClientWin *cw1 = iter1->data;
 				ClientWin *cw2 = iter2->data;
 
 				int dx=0, dy=0;
 				bool positionChanging = newPositionFromCollision(cw1, cw2,
 						&dx, &dy, total_width, total_height);
-
 				if (dx==0 && dy==0 && positionChanging)
 					expansion_coefficient += 0.1;
 
@@ -239,6 +243,8 @@ layout_boxy(MainWin *mw, dlist *windows,
 					colliding = true;
 				}
 			}
+			if (cw1->x != oldx || cw1->y != oldy)
+				stuck = false;
 		}
 
 		iterations++;

--- a/src/layout.c
+++ b/src/layout.c
@@ -42,16 +42,6 @@ void layout_run(MainWin *mw, dlist *windows,
 		enum layoutmode layout) {
 	if (layout == LAYOUTMODE_EXPOSE
 			&& mw->ps->o.exposeLayout == LAYOUT_BOXY) {
-		// set up deterministic random seed
-		// when two windows have the same centre of mass
-		srand(0);
-
-		foreach_dlist (dlist_first(windows)) {
-			ClientWin *cw = iter->data;
-			cw->x = cw->src.x;
-			cw->y = cw->src.y;
-		}
-
 		dlist *sorted_windows = dlist_dup(windows);
 		layout_boxy(mw, sorted_windows, total_width, total_height);
 		dlist_free(sorted_windows);
@@ -177,6 +167,16 @@ void
 layout_boxy(MainWin *mw, dlist *windows,
 		unsigned int *total_width, unsigned int *total_height)
 {
+	// set up deterministic random seed
+	// when two windows have the same centre of mass
+	srand(0);
+
+	foreach_dlist (dlist_first(windows)) {
+		ClientWin *cw = iter->data;
+		cw->x = cw->src.x;
+		cw->y = cw->src.y;
+	}
+
 	float aratio = (float)mw->width / (float)mw->height;
 	float expansion_coefficient = 1.1;
 
@@ -202,7 +202,7 @@ layout_boxy(MainWin *mw, dlist *windows,
 		*total_width = maxx - minx;
 		*total_height = maxy - miny;
 
-		if (!colliding || iterations >= 100)
+		if (!colliding || iterations >= 1000)
 			break;
 		colliding = false;
 

--- a/src/layout.c
+++ b/src/layout.c
@@ -167,10 +167,6 @@ void
 layout_boxy(MainWin *mw, dlist *windows,
 		unsigned int *total_width, unsigned int *total_height)
 {
-	// set up deterministic random seed
-	// when two windows have the same centre of mass
-	srand(0);
-
 	foreach_dlist (dlist_first(windows)) {
 		ClientWin *cw = iter->data;
 		cw->x = cw->src.x;

--- a/src/layout.c
+++ b/src/layout.c
@@ -207,11 +207,11 @@ layout_boxy(MainWin *mw, dlist *windows,
 		colliding = false;
 
 		// expand frame
-		*total_width = expansion_coefficient * (float)(*total_height);
+		*total_width = expansion_coefficient * (float)(*total_width);
 		*total_height = expansion_coefficient * (float)(*total_height);
-		if (*total_width < aratio * (float)(*total_height))
+		if (*total_width <= aratio * (float)(*total_height))
 			*total_width = aratio * (float)(*total_height);
-		else /*if (*total_height < aratio / (float)(*total_width))*/
+		else
 			*total_height = (float)(*total_width) / aratio;
 
 		// collision detection and movement between all window pairs

--- a/src/layout.c
+++ b/src/layout.c
@@ -42,6 +42,10 @@ void layout_run(MainWin *mw, dlist *windows,
 		enum layoutmode layout) {
 	if (layout == LAYOUTMODE_EXPOSE
 			&& mw->ps->o.exposeLayout == LAYOUT_BOXY) {
+		// set up deterministic random seed
+		// when two windows have the same centre of mass
+		srand(0);
+
 		foreach_dlist (dlist_first(windows)) {
 			ClientWin *cw = iter->data;
 			cw->x = cw->src.x;
@@ -49,8 +53,6 @@ void layout_run(MainWin *mw, dlist *windows,
 		}
 
 		dlist *sorted_windows = dlist_dup(windows);
-		dlist_sort(sorted_windows, sort_cw_by_id, 0);
-		dlist_sort(sorted_windows, sort_cw_by_column, 0);
 		layout_boxy(mw, sorted_windows, total_width, total_height);
 		dlist_free(sorted_windows);
 	}
@@ -258,6 +260,9 @@ layout_boxy(MainWin *mw, dlist *windows,
 
 		// collision detection and movement between all window pairs
 		// this is of course O(n^2) complexity
+		dlist_sort(windows, sort_cw_by_id, 0);
+		dlist_sort(windows, sort_cw_by_column, 0);
+
 		for (dlist *iter1 = dlist_first(windows)->next;
 				iter1; iter1=iter1->next) {
 			for (dlist *iter2 = dlist_first(windows);

--- a/src/layout.c
+++ b/src/layout.c
@@ -218,20 +218,6 @@ void
 layout_boxy(MainWin *mw, dlist *windows,
 		unsigned int *total_width, unsigned int *total_height)
 {
-	if (dlist_len(windows) == 0) {
-		*total_width = mw->width;
-		*total_height = mw->height;
-		return;
-	}
-
-	if (dlist_len(windows) == 1) {
-		ClientWin *cw = dlist_first(windows)->data;
-		cw->x = cw->y = 0;
-		*total_width = cw->src.width;
-		*total_height = cw->src.height;
-		return;
-	}
-
 	int iterations = 0;
 	bool colliding = true;
 	while (true) {

--- a/src/layout.c
+++ b/src/layout.c
@@ -171,48 +171,7 @@ layout_xd(MainWin *mw, dlist *windows,
 	dlist_free(rows);
 }
 
-static inline bool
-isIntersecting(ClientWin *cw1, ClientWin *cw2) {
-	int dis = cw1->mainwin->distance / 2;
-	int x1 = cw1->x, x2 = cw2->x;
-	int y1 = cw1->y, y2 = cw2->y;
-	int w1 = cw1->src.width, w2 = cw2->src.width;
-	int h1 = cw1->src.height, h2 = cw2->src.height;
-	return ((x2 - dis <= x1 && x1 < x2 + w2 + dis)
-			|| (x1 - dis <= x2 && x2 < x1 + w1 + dis))
-		&& ((y2 - dis <= y1 && y1 < y2 + h2 + dis)
-			 || (y1 - dis <= y2 && y2 < y1 + h1 + dis));
-}
-
-static inline void
-com(ClientWin *cw, int *x, int *y) {
-	*x = cw->x + cw->src.width / 2;
-	*y = cw->y + cw->src.height / 2;
-}
-
-static inline void
-newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
-		int *dx, int *dy) {
-	if (!isIntersecting(cw1, cw2))
-		return;
-
-    int x1=0, y1=0;
-    com(cw1, &x1, &y1);
-    int x2=0, y2=0;
-    com(cw2, &x2, &y2);
-
-	// if two windows have the same centre of mass,
-	// move in random direction
-	if (x1 == x2 && y1 == y2) {
-		*dx = rand() % 50;
-		*dy = rand() % 50;
-		return;
-	}
-
-	float norm = sqrt((float)((x1-x2)*(x1-x2) + (y1-y2)*(y1-y2)));
-	*dx = (float)(x1 - x2) / (float)norm * 50.0;
-	*dy = (float)(y1 - y2) / (float)norm * 50.0;
-}
+#include "physics.h"
 
 void
 layout_boxy(MainWin *mw, dlist *windows,

--- a/src/physics.c
+++ b/src/physics.c
@@ -1,0 +1,64 @@
+/* Skippy - Seduces Kids Into Perversion
+ *
+ * Copyright (C) 2004 Hyriand <hyriand@thegraveyard.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "skippy.h"
+#include "physics.h"
+
+inline bool
+isIntersecting(ClientWin *cw1, ClientWin *cw2) {
+	int dis = cw1->mainwin->distance / 2;
+	int x1 = cw1->x, x2 = cw2->x;
+	int y1 = cw1->y, y2 = cw2->y;
+	int w1 = cw1->src.width, w2 = cw2->src.width;
+	int h1 = cw1->src.height, h2 = cw2->src.height;
+	return ((x2 - dis <= x1 && x1 < x2 + w2 + dis)
+			|| (x1 - dis <= x2 && x2 < x1 + w1 + dis))
+		&& ((y2 - dis <= y1 && y1 < y2 + h2 + dis)
+			 || (y1 - dis <= y2 && y2 < y1 + h1 + dis));
+}
+
+inline void
+com(ClientWin *cw, int *x, int *y) {
+	*x = cw->x + cw->src.width / 2;
+	*y = cw->y + cw->src.height / 2;
+}
+
+inline void
+newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
+		int *dx, int *dy) {
+	if (!isIntersecting(cw1, cw2))
+		return;
+
+    int x1=0, y1=0;
+    com(cw1, &x1, &y1);
+    int x2=0, y2=0;
+    com(cw2, &x2, &y2);
+
+	// if two windows have the same centre of mass,
+	// move in random direction
+	if (x1 == x2 && y1 == y2) {
+		*dx = rand() % 50;
+		*dy = rand() % 50;
+		return;
+	}
+
+	float norm = sqrt((float)((x1-x2)*(x1-x2) + (y1-y2)*(y1-y2)));
+	*dx = (float)(x1 - x2) / (float)norm * 50.0;
+	*dy = (float)(y1 - y2) / (float)norm * 50.0;
+}

--- a/src/physics.c
+++ b/src/physics.c
@@ -37,14 +37,6 @@ intersectArea(ClientWin *cw1, ClientWin *cw2) {
 		return 0;
 
 	return (right - left) * (bottom - top);
-
-	/*unsigned int intersectx = 0;
-	if ((x2 - dis <= x1 && x1 < x2 + w2 + dis)
-			|| (x1 - dis <= x2 && x2 < x1 + w1 + dis))
-		intersectx = x1 + w1 - x2 - w2;
-	unsigned int intersecty = ;
-		&& ((y2 - dis <= y1 && y1 < y2 + h2 + dis)
-			 || (y1 - dis <= y2 && y2 < y1 + h1 + dis));*/
 }
 
 bool
@@ -59,14 +51,21 @@ newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
 	int dis = cw1->mainwin->distance / 2;
 	int x1 = cw1->x - dis, x2 = cw2->x - dis;
 	int y1 = cw1->y - dis, y2 = cw2->y - dis;
-	int w1 = cw1->src.width, w2 = cw2->src.width;
-	int h1 = cw1->src.height, h2 = cw2->src.height;
+	//int w1 = cw1->src.width, w2 = cw2->src.width;
+	//int h1 = cw1->src.height, h2 = cw2->src.height;
 
-	bool xmajoraxis = abs(x1-x2) > abs(y1-y2);
-	bool triedbothaxis = false;
-	while (*dx == 0 && *dy == 0)
+	int attempts = 0;
+	bool axis_attempted[2];
+	axis_attempted[0] = axis_attempted[1] = false;
+
+	while (*dx == 0 && *dy == 0 && attempts < 2)
 	{
-		if (xmajoraxis)
+		int axis = abs(x1-x2) > abs(y1-y2) ? 0 : 1;
+		if (axis_attempted[axis])
+			axis = !axis;
+		axis_attempted[axis] = true;
+
+		if (axis == 0)
 			*dx = x1 > x2? dis: -dis;
 		else
 			*dy = y1 > y2? dis: -dis;
@@ -86,17 +85,7 @@ newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
 		if (*totalheight < y1 + *dy + h1)
 			*dy = *totalheight - y1 - h1;
 
-		if (triedbothaxis) {
-			break;
-		}
-		else if (xmajoraxis) {
-			xmajoraxis = false;
-			triedbothaxis = true;
-		}
-		else if (!xmajoraxis) {
-			xmajoraxis = true;
-			triedbothaxis = true;
-		}
+		attempts++;
 	}
 
 	return true;

--- a/src/physics.c
+++ b/src/physics.c
@@ -20,47 +20,47 @@
 #include "skippy.h"
 #include "physics.h"
 
-inline bool
-isIntersecting(ClientWin *cw1, ClientWin *cw2) {
+unsigned int
+intersectArea(ClientWin *cw1, ClientWin *cw2) {
 	int dis = cw1->mainwin->distance / 2;
-	int x1 = cw1->x, x2 = cw2->x;
-	int y1 = cw1->y, y2 = cw2->y;
-	int w1 = cw1->src.width, w2 = cw2->src.width;
-	int h1 = cw1->src.height, h2 = cw2->src.height;
-	return ((x2 - dis <= x1 && x1 < x2 + w2 + dis)
+	int x1 = cw1->x - dis, x2 = cw2->x - dis;
+	int y1 = cw1->y - dis, y2 = cw2->y - dis;
+	int w1 = cw1->src.width + dis, w2 = cw2->src.width + dis;
+	int h1 = cw1->src.height + dis, h2 = cw2->src.height + dis;
+
+	int left   = MAX(x1, x2);
+	int top    = MAX(y1, y2);
+	int right  = MIN(x1 + w1, x2 + w2);
+	int bottom = MIN(y1 + h1, y2 + h2);
+
+	if (right < left || bottom < top)
+		return 0;
+
+	return (right - left) * (bottom - top);
+
+	/*unsigned int intersectx = 0;
+	if ((x2 - dis <= x1 && x1 < x2 + w2 + dis)
 			|| (x1 - dis <= x2 && x2 < x1 + w1 + dis))
+		intersectx = x1 + w1 - x2 - w2;
+	unsigned int intersecty = ;
 		&& ((y2 - dis <= y1 && y1 < y2 + h2 + dis)
-			 || (y1 - dis <= y2 && y2 < y1 + h1 + dis));
+			 || (y1 - dis <= y2 && y2 < y1 + h1 + dis));*/
 }
 
-inline void
-com(ClientWin *cw, int *x, int *y) {
-	*x = cw->x + cw->src.width / 2;
-	*y = cw->y + cw->src.height / 2;
-}
-
-inline bool
+bool
 newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
-		int *dx, int *dy, unsigned int *totalwidth, unsigned int *totalheight) {
-	if (!isIntersecting(cw1, cw2))
+		int *dx, int *dy, unsigned int *totalwidth, unsigned int *totalheight)
+{
+	if (intersectArea(cw1, cw2) == 0)
 		return false;
-
-    int x1=0, y1=0;
-    com(cw1, &x1, &y1);
-    int x2=0, y2=0;
-    com(cw2, &x2, &y2);
 
 	// if two windows have the same centre of mass,
 	// move in random direction
 	int dis = cw1->mainwin->distance / 2;
-	if (x1 == x2 && y1 == y2) {
-		bool axis = rand() % 2;
-		if (axis)
-			*dx = rand() % dis;
-		else
-			*dy = rand() % dis;
-		return true;
-	}
+	int x1 = cw1->x - dis, x2 = cw2->x - dis;
+	int y1 = cw1->y - dis, y2 = cw2->y - dis;
+	int w1 = cw1->src.width, w2 = cw2->src.width;
+	int h1 = cw1->src.height, h2 = cw2->src.height;
 
 	bool xmajoraxis = abs(x1-x2) > abs(y1-y2);
 	bool triedbothaxis = false;

--- a/src/physics.c
+++ b/src/physics.c
@@ -39,11 +39,11 @@ com(ClientWin *cw, int *x, int *y) {
 	*y = cw->y + cw->src.height / 2;
 }
 
-inline void
+inline bool
 newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
-		int *dx, int *dy) {
+		int *dx, int *dy, unsigned int *totalwidth, unsigned int *totalheight) {
 	if (!isIntersecting(cw1, cw2))
-		return;
+		return false;
 
     int x1=0, y1=0;
     com(cw1, &x1, &y1);
@@ -53,12 +53,31 @@ newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
 	// if two windows have the same centre of mass,
 	// move in random direction
 	if (x1 == x2 && y1 == y2) {
-		*dx = rand() % 50;
-		*dy = rand() % 50;
-		return;
+		*dx = rand() % 20;
+		*dy = rand() % 20;
+		return true;
 	}
 
 	float norm = sqrt((float)((x1-x2)*(x1-x2) + (y1-y2)*(y1-y2)));
-	*dx = (float)(x1 - x2) / (float)norm * 50.0;
-	*dy = (float)(y1 - y2) / (float)norm * 50.0;
+	if (abs(x1-x2) > abs(y1-y2))
+		*dx = (float)(x1 - x2) / (float)norm * 20.0;
+	else
+		*dy = (float)(y1 - y2) / (float)norm * 20.0;
+
+	x1 = cw1->x;
+	y1 = cw1->y;
+	int w1 = cw1->src.width;
+	int h1 = cw1->src.height;
+
+	if (x1 + *dx < 0)
+		*dx = -x1;
+	if (*totalwidth < x1 + *dx + w1)
+		*dx = *totalwidth - x1 - w1;
+
+	if (y1 + *dy < 0)
+		*dy = -y1;
+	if (*totalheight < y1 + *dy + h1)
+		*dy = *totalheight - y1 - h1;
+
+	return true;
 }

--- a/src/physics.c
+++ b/src/physics.c
@@ -46,8 +46,6 @@ newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
 	if (intersectArea(cw1, cw2) == 0)
 		return false;
 
-	// if two windows have the same centre of mass,
-	// move in random direction
 	int dis = cw1->mainwin->distance / 2;
 	int x1 = cw1->x - dis, x2 = cw2->x - dis;
 	int y1 = cw1->y - dis, y2 = cw2->y - dis;

--- a/src/physics.c
+++ b/src/physics.c
@@ -52,31 +52,52 @@ newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
 
 	// if two windows have the same centre of mass,
 	// move in random direction
+	int dis = cw1->mainwin->distance / 2;
 	if (x1 == x2 && y1 == y2) {
-		*dx = rand() % 20;
-		*dy = rand() % 20;
+		bool axis = rand() % 2;
+		if (axis)
+			*dx = rand() % dis;
+		else
+			*dy = rand() % dis;
 		return true;
 	}
 
-	if (abs(x1-x2) > abs(y1-y2))
-		*dx = x1 > x2? 20: -20;
-	else
-		*dy = y1 > y2? 20: -20;
+	bool xmajoraxis = abs(x1-x2) > abs(y1-y2);
+	bool triedbothaxis = false;
+	while (*dx == 0 && *dy == 0)
+	{
+		if (xmajoraxis)
+			*dx = x1 > x2? dis: -dis;
+		else
+			*dy = y1 > y2? dis: -dis;
 
-	x1 = cw1->x;
-	y1 = cw1->y;
-	int w1 = cw1->src.width;
-	int h1 = cw1->src.height;
+		x1 = cw1->x;
+		y1 = cw1->y;
+		int w1 = cw1->src.width;
+		int h1 = cw1->src.height;
 
-	if (x1 + *dx < 0)
-		*dx = -x1;
-	if (*totalwidth < x1 + *dx + w1)
-		*dx = *totalwidth - x1 - w1;
+		if (x1 + *dx < 0)
+			*dx = -x1;
+		if (*totalwidth < x1 + *dx + w1)
+			*dx = *totalwidth - x1 - w1;
 
-	if (y1 + *dy < 0)
-		*dy = -y1;
-	if (*totalheight < y1 + *dy + h1)
-		*dy = *totalheight - y1 - h1;
+		if (y1 + *dy < 0)
+			*dy = -y1;
+		if (*totalheight < y1 + *dy + h1)
+			*dy = *totalheight - y1 - h1;
+
+		if (triedbothaxis) {
+			break;
+		}
+		else if (xmajoraxis) {
+			xmajoraxis = false;
+			triedbothaxis = true;
+		}
+		else if (!xmajoraxis) {
+			xmajoraxis = true;
+			triedbothaxis = true;
+		}
+	}
 
 	return true;
 }

--- a/src/physics.c
+++ b/src/physics.c
@@ -58,11 +58,10 @@ newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
 		return true;
 	}
 
-	float norm = sqrt((float)((x1-x2)*(x1-x2) + (y1-y2)*(y1-y2)));
 	if (abs(x1-x2) > abs(y1-y2))
-		*dx = (float)(x1 - x2) / (float)norm * 20.0;
+		*dx = x1 > x2? 20: -20;
 	else
-		*dy = (float)(y1 - y2) / (float)norm * 20.0;
+		*dy = y1 > y2? 20: -20;
 
 	x1 = cw1->x;
 	y1 = cw1->y;

--- a/src/physics.h
+++ b/src/physics.h
@@ -1,0 +1,34 @@
+/* Skippy - Seduces Kids Into Perversion
+ *
+ * Copyright (C) 2004 Hyriand <hyriand@thegraveyard.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef SKIPPY_PHYSICS_H
+#define SKIPPY_PHYSICS_H
+
+// calculate and populate windows destination positions
+// switches to different layout algorithms based on user/default config
+void layout_run(MainWin *, dlist *, unsigned int *, unsigned int *, enum layoutmode);
+void layout_xd(MainWin *, dlist *, unsigned int *, unsigned int *);
+void layout_boxy(MainWin *, dlist *, unsigned int *, unsigned int *);
+
+bool isIntersecting(ClientWin *cw1, ClientWin *cw2);
+void com(ClientWin *cw, int *x, int *y);
+void newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
+		int *dx, int *dy);
+
+#endif /* SKIPPY_LAYOUT_H */

--- a/src/physics.h
+++ b/src/physics.h
@@ -20,15 +20,9 @@
 #ifndef SKIPPY_PHYSICS_H
 #define SKIPPY_PHYSICS_H
 
-// calculate and populate windows destination positions
-// switches to different layout algorithms based on user/default config
-void layout_run(MainWin *, dlist *, unsigned int *, unsigned int *, enum layoutmode);
-void layout_xd(MainWin *, dlist *, unsigned int *, unsigned int *);
-void layout_boxy(MainWin *, dlist *, unsigned int *, unsigned int *);
-
 bool isIntersecting(ClientWin *cw1, ClientWin *cw2);
 void com(ClientWin *cw, int *x, int *y);
-void newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
-		int *dx, int *dy);
+bool newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
+		int *dx, int *dy, unsigned int *totalwidth, unsigned int *totalheight);
 
 #endif /* SKIPPY_LAYOUT_H */

--- a/src/physics.h
+++ b/src/physics.h
@@ -20,8 +20,7 @@
 #ifndef SKIPPY_PHYSICS_H
 #define SKIPPY_PHYSICS_H
 
-bool isIntersecting(ClientWin *cw1, ClientWin *cw2);
-void com(ClientWin *cw, int *x, int *y);
+unsigned int intersectArea(ClientWin *cw1, ClientWin *cw2);
 bool newPositionFromCollision(ClientWin *cw1, ClientWin *cw2,
 		int *dx, int *dy, unsigned int *totalwidth, unsigned int *totalheight);
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1126,6 +1126,11 @@ mainloop(session_t *ps, bool activate_on_start) {
 	long first_animated = 0L;
 	bool first_animating = false;
 
+	// set up deterministic random seed
+	// this is only for boxy layout
+	// when two windows have the same centre of mass
+	srand(0);
+
 	switch (ps->o.mode) {
 		case PROGMODE_SWITCH:
 			layout = LAYOUTMODE_SWITCH;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1126,11 +1126,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 	long first_animated = 0L;
 	bool first_animating = false;
 
-	// set up deterministic random seed
-	// this is only for boxy layout
-	// when two windows have the same centre of mass
-	srand(0);
-
 	switch (ps->o.mode) {
 		case PROGMODE_SWITCH:
 			layout = LAYOUTMODE_SWITCH;


### PR DESCRIPTION
#164 

This is a work in progress layout algorithm based on cartoon physics. All there is is pairwise detection (O(n^2) complexity) between all windows, and if there is collision, then split them based on centre of mass by 50 pixels.

Surprisingly, this is already yielding decent results. The major shortcoming being that the final layout is not compact, and does not align.

Criteria for good expose algorithm:
1. Windows must not overlap.
2. Windows stay close to original positions.
3. Windows have compact alignment, thus maximize screen usage.
4. Windows are aligned, for efficient visual cues and keyboard navigation.
5. [OPTIONAL] Newly introduced/removed windows only incrementally alter existing layout algorithm.

Number 5 is not relevant to skippy-xd, as there are no plans to process added/removed windows while skippy-xd is already activated.

It comes as no surprise that a physics based algorithm, based on simple collision, even if the physics is cartoonishly wrong, is able to satisfy criteria 1, 2, 5.

I am thinking to enforce criteria 3, 4 by introducing a shrinking frame around the windows, hopefully it can squeeze compactness and alignment into the layout.

Critically, the squeezing and final stable condition requires force calculations. Hence, a bit more realistic physics calculation is required.

If this turns out successful, then it would mean that a simple and computationally inexpensive algorithm can give a good expose layout algorithm.