### PR TITLE
fix: buffer overrun while writing to fifo

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -420,15 +420,16 @@ send_string_command_to_daemon_via_fifo(
 		}
 	}
 
-	printfdf(false, "(): sending string command to pipe of length %d",
-			(int)strlen(command) + 1);
+	// reserve space for first char and null terminator
+	int command_len = strlen(command) + 2;
+	printfdf(false, "(): sending string command to pipe of length %d", command_len);
 
-	char final_cmd[strlen(command)+1];
+	char final_cmd[command_len];
 	sprintf(final_cmd, "%c%s", (char)strlen(command), command);
 	printfdf(false, "(): string command: %s", final_cmd);
 
 	int fp = open(pipePath, O_WRONLY);
-	int bytes_written = write(fp, final_cmd, strlen(command)+1);
+	int bytes_written = write(fp, final_cmd, command_len);
 	if (bytes_written < strlen(command))
 		printfef(true, "(): incomplete command sent!");
 	close(fp);
@@ -2065,7 +2066,8 @@ load_config_file(session_t *ps)
     // less efficient, may introduce inconsistent default value, and
     // occupies a lot more memory for non-string types.
 	{
-		int pipeStrLen = 3;
+		// two -'s, the first digit of uid/xid and null terminator
+		int pipeStrLen = 5;
 
 		int uid = getuid();
 		{


### PR DESCRIPTION
I am in the process of packaging this application for Fedora. I have created a Fedora Copr repository at https://copr.fedorainfracloud.org/coprs/ledif/skippy-xd/package/skippy-xd, which is similar in spirit to the AUR for Fedora.

There are currently two buffer overruns that cause aborts, which seem to only be exposed when building this in a strict environment such as Fedora's infrastructure. Included in this PR is a small set of changes to fix these bugs:

- In `load_config_file()`, the string buffer length does not properly include the size for the first digit of the uid/xid.
- In `send_string_command_to_daemon_via_fifo()`, the string buffer length does not properly include the size for the first character
