### PR TITLE
Fix non-deterministic stubbed command received error

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -393,7 +393,7 @@ open_pipe(session_t *ps, struct pollfd *r_fd) {
 
 static inline int
 read_pipe(session_t *ps, struct pollfd *r_fd, char *piped_input) {
-	int read_ret = read(ps->fd_pipe, piped_input, 1);
+	int read_ret = read(ps->fd_pipe, piped_input, BUF_LEN);
 	if (0 == read_ret) {
 		printfef(true, "(): EOF reached on pipe \"%s\".", ps->o.pipePath);
 		open_pipe(ps, r_fd);
@@ -404,7 +404,6 @@ read_pipe(session_t *ps, struct pollfd *r_fd, char *piped_input) {
 		//exit(1);
 	}
 
-	assert(1 == read_ret);
 	return read_ret;
 }
 
@@ -446,21 +445,16 @@ send_command_to_daemon_via_fifo(char command, const char *pipePath) {
 static char
 receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 		char *nparams, char **param, char ***str) {
+	char buffer[BUF_LEN];
+	int ret_read = read_pipe(ps, r_fd, &buffer[0]);
 	char cmdlen = 0;
-	read_pipe(ps, r_fd, &cmdlen);
-	if (cmdlen <= 0) {
+	if (ret_read < 1 || (cmdlen = buffer[0]) < ret_read - 2) {
 		printfef(true, "(): stubbed command received");
 		exit(1);
 	}
 
-	char *buffer = malloc(cmdlen);
-	int ret_read = read(ps->fd_pipe, buffer, cmdlen);
-	if (ret_read < cmdlen) {
-		printfef(true, "(): stubbed command received");
-		exit(1);
-	}
-
-	char master_command = buffer[0];
+	char *pbuffer = &buffer[1];
+	char master_command = pbuffer[0];
 
 	if ((master_command & PIPECMD_MULTI_BYTE) == 0) {
 		printfdf(false, "(): received single byte command %d", master_command);
@@ -474,7 +468,7 @@ receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 			exit(1);
 		}
 
-		*nparams = buffer[1];
+		*nparams = pbuffer[1];
 		printfdf(false, "(): received multi-byte command %d of %d bytes and %d parameters",
 				master_command, cmdlen, *nparams);
 		*param = malloc(*nparams * sizeof(char*));
@@ -482,25 +476,22 @@ receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 
 		int k=2;
 		for (int i=0; i < *nparams; i++) {
-			(*param)[i] = buffer[k];
+			(*param)[i] = pbuffer[k];
 			k++;
 
-			char nchar = buffer[k];
+			char nchar = pbuffer[k];
 			printfdf(false, "(): parameter %d takes %d bytes...",
 					(*param)[i], nchar);
 			k++;
 
 			(*str)[i] = malloc(nchar+1);
-			strncpy((*str)[i], buffer + k, nchar);
+			strncpy((*str)[i], pbuffer + k, nchar);
 			(*str)[i][(int)nchar] = '\0';
 			k += nchar;
 
 			printfdf(false, "(): received parameter %d%s", (*param)[i], (*str)[i]);
 		}
 	}
-
-	if (buffer)
-		free(buffer);
 
 	return master_command;
 }

--- a/src/wm.c
+++ b/src/wm.c
@@ -785,7 +785,7 @@ wm_wid_get_prop_rstr(session_t *ps, Window wid, Atom prop) {
 	unsigned long bytes_after_ret = 0;
 	unsigned char *data = NULL;
 	char *ret = NULL;
-	if (Success == XGetWindowProperty(ps->dpy, wid, prop, 0, BUF_LEN,
+	if (Success == XGetWindowProperty(ps->dpy, wid, prop, 0, 128,
 				False, AnyPropertyType, &type_ret, &fmt_ret, &nitems,
 				&bytes_after_ret, &data) && nitems && 8 == fmt_ret)
 		ret = mstrdup((char *) data);


### PR DESCRIPTION
PR #181 fixed two buffer overflow errors. After that fix, @nPHYN1T3 and I have been experiencing non-deterministic error:

The client side app would send non-zero length pipe command, but the daemon side app would claim to have received zero length pipe command, hence exiting.

When the relevant fix from #181 is reverted, the error goes away (for me). My guess is that #181 somehow exposes a non-deterministic error in my environment, going from a negligibly small frequency to a big one (around every 7-10 invocations).

The root cause seem to be how I implemented the pipe reading, where I first read one byte for the command length, and then read the rest of the command. Back when I developed the protocol and communication, I knew writing/reading is a bit wonky.

With this PR, I read the pipe with a fixed (128 character) buffer. This seems to eliminate the wonkiness and stubbed command error for me.