### PR TITLE
Root cause fix pipe stubbed command error

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -453,7 +453,7 @@ receive_string_in_daemon_via_fifo(session_t *ps, struct pollfd *r_fd,
 	char buffer[BUF_LEN];
 	int ret_read = read_pipe(ps, r_fd, &buffer[0]);
 	char cmdlen = 0;
-	if (ret_read < 1 || (cmdlen = buffer[0]) < ret_read - 2) {
+	if (ret_read < 1 || (cmdlen = buffer[0]+2) > ret_read) {
 		printfef(true, "(): stubbed command received");
 		exit(1);
 	}


### PR DESCRIPTION
Fixing the pipe "stubbed command received" error 100%.

I have previously gotten the `<` and `>` mixed up, my bad.

Verified with code inspection, printf, and running the client in an infinite while loop.