### PR TITLE
Maintain expose constancy given the same window positions

### DIFF
--- a/src/layout.c
+++ b/src/layout.c
@@ -61,6 +61,7 @@ void layout_run(MainWin *mw, dlist *windows,
 
 		dlist *sorted_windows = dlist_dup(windows);
 		dlist_sort(sorted_windows, sort_cw_by_id, 0);
+		dlist_sort(sorted_windows, sort_cw_by_row, 0);
 		if (mw->ps->o.exposeLayout == LAYOUT_BOXY)
 			layout_boxy(mw, sorted_windows, total_width, total_height);
 		else if (mw->ps->o.exposeLayout == LAYOUT_COSMOS)


### PR DESCRIPTION
Before expose, first sort by window ID, then by window position