### PR TITLE
Switch cycles/focuses windows before live preview

### DIFF
--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -49,6 +49,7 @@ pseudoTrans = true
 [layout]
 
 # Wait time before displaying switch previews
+# Set = 0 to veto live previews completely
 switchWaitDuration = 100
 
 # Set = 0 to switch off animations

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1283,6 +1283,8 @@ mainloop(session_t *ps, bool activate_on_start) {
 		if (mw && die) {
 			printfdf(false,"(): selecting/canceling and returning to background");
 
+			animating = false;
+
 			// Unmap the main window and all clients, to make sure focus doesn't fall out
 			// when we start setting focus on client window
 			mainwin_unmap(mw);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1866,7 +1866,8 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 					while (ps->o.focus_initial > 0 && mw->client_to_focus) {
 						focus_miniw_next(ps, mw->client_to_focus);
-						childwin_focus(mw->client_to_focus);
+						if (!mw->mapped)
+							childwin_focus(mw->client_to_focus);
 						ps->o.focus_initial--;
 					}
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -809,6 +809,8 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 
 	if (iter) {
 		mw->client_to_focus_on_cancel = (ClientWin *) iter->data;
+		mw->focuslist = dlist_cycle(mw->focuslist,
+				dlist_index_of(mw->focuslist, iter));
 		if (ps->o.focus_initial != 0 && iter)
 		{
 			if (ps->o.focus_initial < 0)

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1758,7 +1758,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 		int timeout = ps->mainwin->poll_time;
 		int time_offset = last_rendered - time_in_millis();
 		timeout -= time_offset;
-		if (timeout < 0)
+		if (timeout < 0 || animating)
 			timeout = 0;
 		poll(r_fd, (r_fd[1].fd >= 0 ? 2: 1), timeout);
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1530,7 +1530,8 @@ mainloop(session_t *ps, bool activate_on_start) {
 						ps->o.movePointer);
 			}
 
-			continue; // while animating, do not allow user actions
+			if (layout != LAYOUTMODE_SWITCH)
+				continue; // while animating, do not allow user actions
 		}
 
 		if (layout != LAYOUTMODE_SWITCH
@@ -1795,7 +1796,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 				ps->o.focus_initial = -((piped_input & PIPECMD_PREV) > 0)
 					+ ((piped_input & PIPECMD_NEXT) > 0);
 
-				if (!mw || !mw->mapped)
+				if (!mw /*|| !mw->mapped*/)
 				{
 					if (piped_input & PIPECMD_SWITCH) {
 						ps->o.mode = PROGMODE_SWITCH;
@@ -1851,7 +1852,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 						mw->refocus = die = true;
 					}
 				}
-				else if (mw && mw->mapped)
+				else if (mw /*&& mw->mapped*/)
 				{
 					printfdf(false, "(): cycling window");
 					fflush(stdout);fflush(stderr);
@@ -1861,6 +1862,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 					while (ps->o.focus_initial > 0 && mw->client_to_focus) {
 						focus_miniw_next(ps, mw->client_to_focus);
+						childwin_focus(mw->client_to_focus);
 						ps->o.focus_initial--;
 					}
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -827,7 +827,8 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 	if (first) {
 		mw->client_to_focus = first->data;
 		mw->client_to_focus->focused = 1;
-		childwin_focus(mw->client_to_focus);
+		if (!mw->mapped)
+			childwin_focus(mw->client_to_focus);
 	}
 }
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -809,8 +809,6 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 
 	if (iter) {
 		mw->client_to_focus_on_cancel = (ClientWin *) iter->data;
-		mw->focuslist = dlist_cycle(mw->focuslist,
-				dlist_index_of(mw->focuslist, iter));
 		if (ps->o.focus_initial != 0 && iter)
 		{
 			if (ps->o.focus_initial < 0)

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1223,6 +1223,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 	bool activate = activate_on_start;
 	bool pending_damage = false;
 	long last_rendered = 0L;
+	long last_animated = 0L;
 	enum layoutmode layout = LAYOUTMODE_EXPOSE;
 	bool toggling = !ps->o.pivotkey;
 	bool animating = activate;
@@ -1268,7 +1269,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 			activate = false;
 
 			if (skippy_activate(ps->mainwin, layout)) {
-				last_rendered = time_in_millis();
+				last_animated = last_rendered = time_in_millis();
 				mw = ps->mainwin;
 				pending_damage = false;
 				first_animated = time_in_millis();
@@ -1437,7 +1438,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 		// animation!
 		if (mw && animating) {
 			int timeslice = time_in_millis() - first_animated;
-			int starttime = last_rendered + (1000.0 / ps->o.animationRefresh) - first_animated;
+			int starttime = last_animated + (1000.0 / ps->o.animationRefresh) - first_animated;
 			int stabletime = ps->o.animationDuration;
 			if (layout == LAYOUTMODE_SWITCH) {
 				if (ps->o.switchWaitDuration == 0) {
@@ -1476,11 +1477,11 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 				anime(ps->mainwin, ps->mainwin->clients,
 					((float)timeslice)/(float)ps->o.animationDuration);
-				last_rendered = time_in_millis();
+				last_animated = last_rendered = time_in_millis();
 
 				if (layout == LAYOUTMODE_SWITCH
 				&& ps->o.switchLayout == LAYOUT_COSMOS)
-					last_rendered -= ps->o.switchWaitDuration;
+					last_animated = last_rendered -= ps->o.switchWaitDuration;
 
 				XFlush(ps->dpy);
 			}
@@ -1520,7 +1521,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 				anime(ps->mainwin, ps->mainwin->clients, 1);
 				animating = false;
-				last_rendered = time_in_millis();
+				last_animated = last_rendered = time_in_millis();
 
 				if (layout == LAYOUTMODE_PAGING) {
 					foreach_dlist (mw->dminis) {

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -825,6 +825,7 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 	if (first) {
 		mw->client_to_focus = first->data;
 		mw->client_to_focus->focused = 1;
+		childwin_focus(mw->client_to_focus);
 	}
 }
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1436,7 +1436,10 @@ mainloop(session_t *ps, bool activate_on_start) {
 			int starttime = last_rendered + (1000.0 / ps->o.animationRefresh) - first_animated;
 			int stabletime = ps->o.animationDuration;
 			if (layout == LAYOUTMODE_SWITCH) {
-				if (ps->o.switchLayout == LAYOUT_XD) {
+				if (ps->o.switchWaitDuration == 0) {
+					starttime = stabletime = timeslice + 1;
+				}
+				else if (ps->o.switchLayout == LAYOUT_XD) {
 					starttime = ps->o.switchWaitDuration + 1;
 					stabletime = ps->o.switchWaitDuration;
 				}


### PR DESCRIPTION
Previously, switch can only focus on next window until live preview pops up (controlled by config option `layout/switchWaitDuration`.

This PR enables cycling through all windows before live preview pops up.

In addition, when the `layout/switchWaitDuration = 0`, live preview never pops up for switch.

This is a pretty complex PR that introduces special cases on switch, changes to important code paths, and potentially messes up Z-order.

This PR needs to be tested carefully before merging.