### PR TITLE
switch/cosmos use cosmos ordering except first next

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -840,6 +840,9 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 		if (iter && !mw->mapped)
 			childwin_focus(mw->client_to_focus);
 	}
+
+	if (layout == LAYOUTMODE_SWITCH && ps->o.switchLayout == LAYOUT_COSMOS)
+		dlist_sort(mw->focuslist, sort_cw_by_column, 0);
 }
 
 static void


### PR DESCRIPTION
Switch next/prev ordering:

- The first "next" goes to the previous window. In particular, quick alt-tabs alternate between two windows
- Starting the subsequent alt-tab or "next" command, regardless whether live preview pops up:
    - When layout is xd, ordering is as before, based on z-order
    - When layout is cosmos, ordering is based on row/column