### PR TITLE
Using --wm-class on the same command combines the entries

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -2283,7 +2283,19 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 				ps->o.multiselect = true;
 				break;
 			case OPT_WM_CLASS:
-				ps->o.wm_class = mstrdup(optarg);
+				if (ps->o.wm_class == NULL)
+					ps->o.wm_class = mstrdup(optarg);
+				else {
+					char* newclass = malloc(
+							(strlen(ps->o.wm_class) + strlen(optarg) + 3)*sizeof(char));
+					newclass[0] = '('; newclass[1] = '\0';
+					strcat(newclass, ps->o.wm_class);
+					strcat(newclass, "|");
+					strcat(newclass, optarg);
+					strcat(newclass, ")");
+					free(ps->o.wm_class);
+					ps->o.wm_class = newclass;
+				}
 				break;
 			case OPT_WM_STATUS:
 				int anchor = 0;


### PR DESCRIPTION
e.g. `skippy-xd --expose --wm-class XTerm --wm-class firefox` would display both XTerm and firefox windows