### PR TITLE
Tooltip can show either window class or window title

### DIFF
--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -139,6 +139,7 @@ backgroundTinting = true
 
 [tooltip]
 show = true
+option = windowClass
 offsetX = 0
 offsetY = -5
 width = 0.8

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -724,7 +724,7 @@ clientwin_tooltip(ClientWin *cw) {
 		int len = 0;
 		FcChar8 *label = NULL;
 
-		if (cw->mode == CLIDISP_DESKTOP) {
+		if (ps->o.tooltip_option == 0 || cw->mode == CLIDISP_DESKTOP) {
 			label = wm_get_window_title(ps, cw->wid_client, &len);
 
 			if (!label)

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -2674,6 +2674,13 @@ load_config_file(session_t *ps)
 		ps->o.updatetooltip |= update_and_flag(config, "tooltip", "font", "fixed-11:weight=bold", &ps->o.tooltip_font);
 	}
     config_get_bool_wrap(config, "tooltip", "show", &ps->o.tooltip_show);
+	{
+		const char* tooltipoption = config_get(config, "tooltip", "option", "windowClass");
+		if (strcmp(tooltipoption, "windowTitle") == 0)
+			ps->o.tooltip_option = 0;
+		else
+			ps->o.tooltip_option = 1;
+	}
     config_get_int_wrap(config, "tooltip", "offsetX", &ps->o.tooltip_offsetX, INT_MIN, INT_MAX);
     config_get_int_wrap(config, "tooltip", "offsetY", &ps->o.tooltip_offsetY, INT_MIN, INT_MAX);
     config_get_double_wrap(config, "tooltip", "width", &ps->o.tooltip_width, 0.0, 1.0);

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -252,6 +252,7 @@ typedef struct {
 	bool desktopTinting;
 
 	bool tooltip_show;
+	int tooltip_option;
 	int tooltip_offsetX;
 	int tooltip_offsetY;
 	double tooltip_width;
@@ -362,6 +363,7 @@ typedef struct {
 	.desktopTinting = true, \
 \
 	.tooltip_show = true, \
+	.tooltip_option = 1, \
 	.tooltip_offsetX = 0, \
 	.tooltip_offsetY = -5, \
 	.tooltip_width = 0.8, \


### PR DESCRIPTION
Controlled by config option `tooltip/option` which takes values `windowClass`, `windowTitle`.

Window class by default.