### PR TITLE
Remove config option system/updateFreq

### DIFF
--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -30,9 +30,6 @@ daemonPath = /tmp/skippy-xd-fifo
 # File path for daemon-to-client communication
 clientPath = /tmp/skippy-xd-fofi
 
-# Frequency to update pixmaps
-updateFreq = 60.0
-
 # This queries the list of windows
 # Depending on your window manager, you may want to choose between
 # XQueryTree, _NET_CLIENT_LIST, _WIN_CLIENT_LIST

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -175,11 +175,6 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	check_keybindings_conflict(ps->o.config_path, "keysNext", mw->keysyms_Next, "keysCancel", mw->keysyms_Cancel);
 	check_keybindings_conflict(ps->o.config_path, "keysNext", mw->keysyms_Next, "keysSelect", mw->keysyms_Select);
 	check_keybindings_conflict(ps->o.config_path, "keysCancel", mw->keysyms_Cancel, "keysSelect", mw->keysyms_Select);
-	
-	if (ps->o.updateFreq != 0.0)
-		mw->poll_time = (1.0 / ps->o.updateFreq) * 1000.0;
-	else
-		mw->poll_time = (1.0 / 60.0) * 1000.0;
 
 	mw->colormap = XCreateColormap(dpy, ps->root, mw->visual, AllocNone);
 	mw->format = XRenderFindVisualFormat(dpy, mw->visual);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1778,11 +1778,14 @@ mainloop(session_t *ps, bool activate_on_start) {
 		XFlush(ps->dpy);
 
 		// Poll for events
-		int timeout = ps->mainwin->poll_time;
-		int time_offset = last_rendered - time_in_millis();
-		timeout -= time_offset;
-		if (timeout < 0 || animating)
-			timeout = 0;
+		int timeout = -1;
+		if (mw && !toggling) {
+			timeout = ps->mainwin->poll_time;
+			int time_offset = last_rendered - time_in_millis();
+			timeout -= time_offset;
+			if (timeout < 0 || animating)
+				timeout = 0;
+		}
 		poll(r_fd, (r_fd[1].fd >= 0 ? 2: 1), timeout);
 
 		// Handle daemon commands

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1780,9 +1780,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 		// Poll for events
 		int timeout = -1;
 		if (mw && !toggling) {
-			timeout = ps->mainwin->poll_time;
-			int time_offset = last_rendered - time_in_millis();
-			timeout -= time_offset;
+			timeout = (1.0 / 60.0) * 1000.0 + time_in_millis() - last_rendered;
 			if (timeout < 0 || animating)
 				timeout = 0;
 		}
@@ -2502,7 +2500,6 @@ load_config_file(session_t *ps)
 		else if (tmp && strcmp(tmp, "_WIN_CLIENT_LIST") == 0)
 			ps->o.clientList = 2;
 	}
-    config_get_double_wrap(config, "system", "updateFreq", &ps->o.updateFreq, -1000.0, 1000.0);
     config_get_bool_wrap(config, "system", "pseudoTrans", &ps->o.pseudoTrans);
 
 	{

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -201,7 +201,6 @@ typedef struct {
 	bool enforceFocus;
 	char *pipePath;
 	char *pipePath2;
-	double updateFreq;
 	int clientList;
 	bool pseudoTrans;
 
@@ -305,7 +304,6 @@ typedef struct {
 	.enforceFocus = true, \
 	.pipePath = NULL, \
 	.pipePath2 = NULL, \
-	.updateFreq = 60.0, \
 	.clientList = 0, \
 	.pseudoTrans = true, \
 \


### PR DESCRIPTION
Currently the main loop polls for X events and pipe commands, with a timeout controlled by config option `system/updateFreq`, with default option 60 Hz.

Turns out the poll is only required for pivot key polling.

Hence, poll ONLY when skippy-xd is activated on pivot mode.

This saves the tiiiny bit of CPU cycles when skippy-xd daemon is running in the background.

Remove `system/updateFreq`, and hard code pivot key polling to 60 Hz.