### PR TITLE
Optimize XDamage events processing

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1673,6 +1673,23 @@ mainloop(session_t *ps, bool activate_on_start) {
 				if (iter) {
 					((ClientWin *)iter->data)->damaged = true;
 				}
+				num_events--;
+
+				{
+					int ev_prev = ev.type;
+					XEvent ev_next = { };
+					while (num_events > 0)
+					{
+						XPeekEvent(ps->dpy, &ev_next);
+						Window wid2 = ev_window(ps, &ev_next);
+
+						if(ev_next.type != ev_prev || wid2 != wid)
+							break;
+
+						XNextEvent(ps->dpy, &ev);
+						num_events--;
+					}
+				}
 			}
 			else if (mw && wid == mw->window && !die) {
 				if (ev.type == FocusOut)


### PR DESCRIPTION
From my testing typically 1-5 events can be skipped, kind of meaning double to 6x processing of redrawing events.

That said, this event is already optimized previously with `pending_damage`, so this optimization should not be that substantial.