### PR TITLE
Config option system/enforceFocus -> bindings/enforceFocus

### DIFF
--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -19,11 +19,6 @@
 
 [system]
 
-# When focus is stolen off skippy-xd
-# E.g. a window is newly created during skippy-xd activation
-# Focus back on skippy-xd
-enforceFocus = true
-
 # File path for client-to-daemon communication
 daemonPath = /tmp/skippy-xd-fifo
 
@@ -180,6 +175,11 @@ exposeShowAllDesktops = false
 persistentFiltering = false
 
 [bindings]
+
+# When focus is stolen off skippy-xd
+# E.g. a window is newly created during skippy-xd activation
+# Focus back on skippy-xd
+enforceFocus = true
 
 # After this time, pivot "locks" into toggle mode
 # And the pivot key no longer needs to be held

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -2481,8 +2481,6 @@ load_config_file(session_t *ps)
     // less efficient, may introduce inconsistent default value, and
     // occupies a lot more memory for non-string types.
 
-	config_get_bool_wrap(config, "system", "enforceFocus", &ps->o.enforceFocus);
-
 	{
 		// two -'s, the first digit of uid/xid and null terminator
 		int pipeStrLen0 = 7;
@@ -2727,6 +2725,7 @@ load_config_file(session_t *ps)
     config_get_bool_wrap(config, "filter", "exposeShowAllDesktops", &ps->o.exposeShowAllDesktops);
     config_get_bool_wrap(config, "filter", "persistentFiltering", &ps->o.persistentFiltering);
 
+	config_get_bool_wrap(config, "bindings", "enforceFocus", &ps->o.enforceFocus);
     config_get_int_wrap(config, "bindings", "pivotLockingTime", &ps->o.pivotLockingTime, 0, 20);
 
     // load keybindings settings

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -198,7 +198,6 @@ typedef struct {
 	KeyCode pivotkey;
 	bool multiselect;
 
-	bool enforceFocus;
 	char *pipePath;
 	char *pipePath2;
 	int clientList;
@@ -277,6 +276,7 @@ typedef struct {
 	int *wm_status;
 	char *wm_status_str;
 
+	bool enforceFocus;
 	int pivotLockingTime;
 	enum cliop bindings_miwMouse[MAX_MOUSE_BUTTONS];
 	char *bindings_keysUp;
@@ -302,7 +302,6 @@ typedef struct {
 	.pivotkey = 0, \
 	.multiselect = false, \
 \
-	.enforceFocus = true, \
 	.pipePath = NULL, \
 	.pipePath2 = NULL, \
 	.clientList = 0, \
@@ -375,6 +374,7 @@ typedef struct {
 	.tooltip_textShadow = NULL, \
 	.tooltip_font = NULL, \
 \
+	.enforceFocus = true, \
 	.pivotLockingTime = 0, \
 }
 


### PR DESCRIPTION
Move config option `enforceFocus` from `system` to `bindings`.

I think `bindings` is more appropriate because this option controls whether the keyboard input goes to skippy-xd.

In addition, this config option can be reloaded with `skippy-xd config-reload`.

After this move, all config options in `system` actually require restarting skippy-xd.