### PR TITLE
Rename skippy-xd window titles

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -148,7 +148,7 @@ clientwin_create(MainWin *mw, Window client) {
 		goto clientwin_create_err;
 
 	{
-		static const char *PREFIX = "mini window of ";
+		static const char *PREFIX = "skippy-xd preview window ";
 		const int len = strlen(PREFIX) + 20;
 		char *str = allocchk(malloc(len));
 		snprintf(str, len, "%s%#010lx", PREFIX, cw->src.window);
@@ -724,7 +724,11 @@ clientwin_tooltip(ClientWin *cw) {
 		int len = 0;
 		FcChar8 *label = NULL;
 
-		if (ps->o.tooltip_option == 0 || cw->mode == CLIDISP_DESKTOP) {
+		if (cw->mode == CLIDISP_DESKTOP) {
+			label = wm_get_desktop_name(mw->ps, cw->slots);
+			len = strlen((char*)label);
+		}
+		else if (ps->o.tooltip_option == 0) {
 			label = wm_get_window_title(ps, cw->wid_client, &len);
 
 			if (!label)

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -111,7 +111,7 @@ mainwin_create(session_t *ps) {
 	if (!mw->window)
 		goto mainwin_create_err;
 
-	wm_wid_set_info(ps, mw->window, "skippy-xd main window", None);
+	wm_wid_set_info(ps, mw->window, "skippy-xd fullscreen window", None);
 
 	mainwin_create_pixmap(mw);
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1061,8 +1061,14 @@ init_paging_layout(MainWin *mw, enum layoutmode layout, Window leader)
 
 			{
 				unsigned char *str = wm_get_desktop_name(mw->ps, desktop_idx);
-				wm_wid_set_info(cw->mainwin->ps, cw->mini.window, (char *) str, None);
+				char *str1 = "skippy-xd page ";
+				char *str2 = malloc(sizeof(char)
+						* (strlen(str1) + strlen((char*) str) + 1));
+				strcpy(str2, str1);
+				strcat(str2, (char*) str);
+				wm_wid_set_info(cw->mainwin->ps, cw->mini.window, (char *) str2, None);
 				free(str);
+				free(str2);
 			}
 
 			cw->zombie = false;

--- a/src/tooltip.c
+++ b/src/tooltip.c
@@ -92,7 +92,7 @@ tooltip_create(MainWin *mw) {
 		tooltip_destroy(tt);
 		return 0;
 	}
-	wm_wid_set_info(ps, tt->window, "skippy-xd tooltip", _NET_WM_WINDOW_TYPE_TOOLTIP);
+	wm_wid_set_info(ps, tt->window, "skippy-xd label", _NET_WM_WINDOW_TYPE_TOOLTIP);
 
 	tmp = ps->o.tooltip_border;
 	if(! XftColorAllocName(ps->dpy, mw->visual, mw->colormap, tmp, &tt->border))

--- a/src/wm.c
+++ b/src/wm.c
@@ -945,7 +945,7 @@ wm_wid_set_info(session_t *ps, Window wid, const char *name,
 		Atom window_type) {
 	// Set window name
 	{
-		char *textcpy = mstrjoin(" ", name);
+		char *textcpy = mstrdup(name);
 		{
 			XTextProperty text_prop = { };
 			if (Success == XmbTextListToTextProperty(ps->dpy, &textcpy, 1,


### PR DESCRIPTION
Window title change:

Fullscreen window: "skippy-xd main window" -> "skippy-xd fullscreen window"
Preview windows: "mini window of 0xXXXX" -> "skippy-xd preview window 0xXXXX"
Paging windows: "[virtual desktop name]" -> "skippy-xd page [virtual desktop name]"
Label windows: "skippy-xd tooltip" -> "skippy-xd label"

The window class is always "skippy-xd"