### PR TITLE
keysSelect and keysCancel processed on key release without lag

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -869,7 +869,25 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 			focus_miniw_prev(ps, cw->mainwin->client_to_focus);
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_Next, evk->keycode))
 			focus_miniw_next(ps, cw->mainwin->client_to_focus);
-		else if (arr_keycodes_includes(cw->mainwin->keycodes_Cancel, evk->keycode))
+	}
+
+	else if (ev->type == KeyRelease) {
+		printfdf(false, "(): else if (ev->type == KeyRelease) {");
+		printfdf(false, "(): keycode: %d:", evk->keycode);
+
+		if (mw->client_to_focus->mode != CLIDISP_DESKTOP) {
+			if (arr_keycodes_includes(mw->keycodes_Iconify, evk->keycode)) {
+				shadow_clientwindow(cw, CLIENTOP_ICONIFY);
+			}
+			else if (arr_keycodes_includes(mw->keycodes_Shade, evk->keycode)) {
+				shadow_clientwindow(cw, CLIENTOP_SHADE_EWMH);
+			}
+			else if (arr_keycodes_includes(mw->keycodes_Close, evk->keycode)) {
+				return close_clientwindow(cw, CLIENTOP_CLOSE_EWMH);
+			}
+		}
+
+		if (arr_keycodes_includes(cw->mainwin->keycodes_Cancel, evk->keycode))
 		{
 			mw->refocus = true;
 			return 1;
@@ -878,29 +896,7 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 		{
 			return select_clientwindow(cw, CLIENTOP_FOCUS);
 		}
-		cw->mainwin->pressed_key = true;
 	}
-
-	else if (ev->type == KeyRelease) {
-		printfdf(false, "(): else if (ev->type == KeyRelease) {");
-		printfdf(false, "(): keycode: %d:", evk->keycode);
-
-		if (cw->mainwin->pressed_key) {
-			if (mw->client_to_focus->mode != CLIDISP_DESKTOP) {
-				if (arr_keycodes_includes(mw->keycodes_Iconify, evk->keycode)) {
-					shadow_clientwindow(cw, CLIENTOP_ICONIFY);
-				}
-				else if (arr_keycodes_includes(mw->keycodes_Shade, evk->keycode)) {
-					shadow_clientwindow(cw, CLIENTOP_SHADE_EWMH);
-				}
-				else if (arr_keycodes_includes(mw->keycodes_Close, evk->keycode)) {
-					return close_clientwindow(cw, CLIENTOP_CLOSE_EWMH);
-				}
-			}
-		}
-		else
-			printfdf(false, "(): KeyRelease %u ignored.", evk->keycode);
-    }
 
 	else if (ev->type == ButtonPress) {
 		cw->mainwin->pressed_mouse = true;

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -407,7 +407,7 @@ mainwin_map(MainWin *mw) {
 
 	wm_set_fullscreen(ps, mw->window, mw->x, mw->y, mw->width, mw->height);
 	mw->pressed = NULL;
-	mw->pressed_key = mw->pressed_mouse = false;
+	mw->pressed_mouse = false;
 	XMapWindow(ps->dpy, mw->window);
 	XRaiseWindow(ps->dpy, mw->window);
 

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -27,8 +27,6 @@ struct _mainwin_t {
 	int depth;
 	dlist *clients;
 	
-	/// @brief Whether the KeyRelease events should already be acceptable.
-	bool pressed_key;
 	/// @brief Whether the ButtonRelease events should already be acceptable.
 	bool pressed_mouse;
 	int poll_time;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1812,7 +1812,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 		// Poll for events
 		int timeout = -1;
-		if (mw && !toggling) {
+		if (mw) {
 			timeout = (1.0 / 60.0) * 1000.0 + time_in_millis() - last_rendered;
 			if (timeout < 0)
 				timeout = 0;


### PR DESCRIPTION
This is not a perfect fix.

Turns out when I did #314, some X events would be processed, with a lag. This includes key release and mouse button release, but not key press.

The root cause of this is not yet found.

This PR polls at 60 Hz only when skippy-xd is activated, so that key/mouse release does not lag, and reinstate key select/cancel on key release.

The root cause will continue to be investigated.