### PR TITLE
Select/cancel on key release, no lag, no polling

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -869,25 +869,7 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 			focus_miniw_prev(ps, cw->mainwin->client_to_focus);
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_Next, evk->keycode))
 			focus_miniw_next(ps, cw->mainwin->client_to_focus);
-	}
-
-	else if (ev->type == KeyRelease) {
-		printfdf(false, "(): else if (ev->type == KeyRelease) {");
-		printfdf(false, "(): keycode: %d:", evk->keycode);
-
-		if (mw->client_to_focus->mode != CLIDISP_DESKTOP) {
-			if (arr_keycodes_includes(mw->keycodes_Iconify, evk->keycode)) {
-				shadow_clientwindow(cw, CLIENTOP_ICONIFY);
-			}
-			else if (arr_keycodes_includes(mw->keycodes_Shade, evk->keycode)) {
-				shadow_clientwindow(cw, CLIENTOP_SHADE_EWMH);
-			}
-			else if (arr_keycodes_includes(mw->keycodes_Close, evk->keycode)) {
-				return close_clientwindow(cw, CLIENTOP_CLOSE_EWMH);
-			}
-		}
-
-		if (arr_keycodes_includes(cw->mainwin->keycodes_Cancel, evk->keycode))
+		else if (arr_keycodes_includes(cw->mainwin->keycodes_Cancel, evk->keycode))
 		{
 			mw->refocus = true;
 			return 1;
@@ -896,7 +878,29 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 		{
 			return select_clientwindow(cw, CLIENTOP_FOCUS);
 		}
+		cw->mainwin->pressed_key = true;
 	}
+
+	else if (ev->type == KeyRelease) {
+		printfdf(false, "(): else if (ev->type == KeyRelease) {");
+		printfdf(false, "(): keycode: %d:", evk->keycode);
+
+		if (cw->mainwin->pressed_key) {
+			if (mw->client_to_focus->mode != CLIDISP_DESKTOP) {
+				if (arr_keycodes_includes(mw->keycodes_Iconify, evk->keycode)) {
+					shadow_clientwindow(cw, CLIENTOP_ICONIFY);
+				}
+				else if (arr_keycodes_includes(mw->keycodes_Shade, evk->keycode)) {
+					shadow_clientwindow(cw, CLIENTOP_SHADE_EWMH);
+				}
+				else if (arr_keycodes_includes(mw->keycodes_Close, evk->keycode)) {
+					return close_clientwindow(cw, CLIENTOP_CLOSE_EWMH);
+				}
+			}
+		}
+		else
+			printfdf(false, "(): KeyRelease %u ignored.", evk->keycode);
+    }
 
 	else if (ev->type == ButtonPress) {
 		cw->mainwin->pressed_mouse = true;

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -869,15 +869,6 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 			focus_miniw_prev(ps, cw->mainwin->client_to_focus);
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_Next, evk->keycode))
 			focus_miniw_next(ps, cw->mainwin->client_to_focus);
-		else if (arr_keycodes_includes(cw->mainwin->keycodes_Cancel, evk->keycode))
-		{
-			mw->refocus = true;
-			return 1;
-		}
-		else if (arr_keycodes_includes(cw->mainwin->keycodes_Select, evk->keycode))
-		{
-			return select_clientwindow(cw, CLIENTOP_FOCUS);
-		}
 		cw->mainwin->pressed_key = true;
 	}
 
@@ -886,6 +877,16 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 		printfdf(false, "(): keycode: %d:", evk->keycode);
 
 		if (cw->mainwin->pressed_key) {
+			if (arr_keycodes_includes(cw->mainwin->keycodes_Cancel, evk->keycode))
+			{
+				mw->refocus = true;
+				return 1;
+			}
+			else if (arr_keycodes_includes(cw->mainwin->keycodes_Select, evk->keycode))
+			{
+				return select_clientwindow(cw, CLIENTOP_FOCUS);
+			}
+
 			if (mw->client_to_focus->mode != CLIDISP_DESKTOP) {
 				if (arr_keycodes_includes(mw->keycodes_Iconify, evk->keycode)) {
 					shadow_clientwindow(cw, CLIENTOP_ICONIFY);

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -407,7 +407,7 @@ mainwin_map(MainWin *mw) {
 
 	wm_set_fullscreen(ps, mw->window, mw->x, mw->y, mw->width, mw->height);
 	mw->pressed = NULL;
-	mw->pressed_mouse = false;
+	mw->pressed_key = mw->pressed_mouse = false;
 	XMapWindow(ps->dpy, mw->window);
 	XRaiseWindow(ps->dpy, mw->window);
 

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -27,6 +27,8 @@ struct _mainwin_t {
 	int depth;
 	dlist *clients;
 	
+	/// @brief Whether the KeyRelease events should already be acceptable.
+	bool pressed_key;
 	/// @brief Whether the ButtonRelease events should already be acceptable.
 	bool pressed_mouse;
 	int poll_time;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1812,7 +1812,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 		// Poll for events
 		int timeout = -1;
-		if (mw) {
+		if (mw && !toggling) {
 			timeout = (1.0 / 60.0) * 1000.0 + time_in_millis() - last_rendered;
 			if (timeout < 0)
 				timeout = 0;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1812,7 +1812,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 		// Poll for events
 		int timeout = -1;
-		if (mw && !toggling) {
+		if (mw && (!toggling || mw->pressed_key || mw->pressed_mouse)) {
 			timeout = (1.0 / 60.0) * 1000.0 + time_in_millis() - last_rendered;
 			if (timeout < 0)
 				timeout = 0;


### PR DESCRIPTION
This is likely the best solution:

Select/cancel on key/mouse release.

Originally (not written by me) there were booleans to indicate key or mouse is pressed. I don't think they were actually used.

Of course, these two booleans are updated in event driven manner, through KeyPress event, without polling.

We can poll at 60 Hz for key/mouse release event *only* when skippy-xd is activated, and key/mouse is pressed, indicated by the booleans.

(Of course we also pll at 60 Hz for pivot mode, that is always the case).

This limits polling to minimum, perhaps theoretical minimum.