### PR TITLE
Showonlycurrentmonitor

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -53,6 +53,8 @@ clientwin_filter_func(dlist *l, void *data) {
 	session_t *ps = mw->ps;
 
 #ifdef CFG_XINERAMA
+	clientwin_movecoord(cw, mw->multiplier, mw->xoff, mw->yoff, 1);
+
 	if (mw->xin_active && !INTERSECTS(cw->src.x, cw->src.y, cw->src.width,
 				cw->src.height, mw->xin_active->x_org, mw->xin_active->y_org,
 				mw->xin_active->width, mw->xin_active->height))
@@ -631,7 +633,7 @@ void clientwin_prepmove(ClientWin *cw)
 }
 
 void
-clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
+clientwin_movecoord(ClientWin *cw, float f, int x, int y, float timeslice)
 {
 	cw->factor = f;
 	{
@@ -644,8 +646,15 @@ clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
 		cw->mini.width = cw->src.width * f;
 		cw->mini.height = cw->src.height * f;
 	}
+}
 
-	XMoveResizeWindow(cw->mainwin->ps->dpy, cw->mini.window, cw->mini.x, cw->mini.y, cw->mini.width, cw->mini.height);
+void
+clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
+{
+	clientwin_movecoord(cw, f, x, y, timeslice);
+
+	XMoveResizeWindow(cw->mainwin->ps->dpy, cw->mini.window,
+			cw->mini.x, cw->mini.y, cw->mini.width, cw->mini.height);
 
 	clientwin_round_corners(cw);
 }

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -55,9 +55,10 @@ clientwin_filter_func(dlist *l, void *data) {
 #ifdef CFG_XINERAMA
 	clientwin_movecoord(cw, mw->multiplier, mw->xoff, mw->yoff, 1);
 
-	if (mw->xin_active && !INTERSECTS(cw->src.x, cw->src.y, cw->src.width,
-				cw->src.height, mw->xin_active->x_org, mw->xin_active->y_org,
-				mw->xin_active->width, mw->xin_active->height))
+	if (mw->xin_active && !INTERSECTS(
+			cw->src.x, cw->src.y, cw->src.width, cw->src.height,
+			mw->xin_active->x_org, mw->xin_active->y_org,
+			mw->xin_active->width, mw->xin_active->height))
 		return false;
 #endif
 

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -96,6 +96,7 @@ int clientwin_sort_func(dlist *, dlist *, void *);
 ClientWin *clientwin_create(MainWin *, Window);
 void clientwin_destroy(ClientWin *, bool destroyed);
 void clientwin_prepmove(ClientWin *);
+void clientwin_movecoord(ClientWin *, float, int, int, float);
 void clientwin_move(ClientWin *, float, int, int, float);
 void clientwin_map(ClientWin *);
 void clientwin_unmap(ClientWin *);

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -396,7 +396,10 @@ mainwin_update(MainWin *mw)
 	mw->width = iter->width;
 	mw->height = iter->height;
 	XMoveResizeWindow(ps->dpy, mw->window, iter->x_org, iter->y_org, mw->width, mw->height);
+
 	mw->xin_active = iter;
+	if (ps->o.xinerama_showAll)
+		mw->xin_active = 0;
 #endif /* CFG_XINERAMA */
 	mainwin_update_background(mw);
 }

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -398,7 +398,7 @@ mainwin_update(MainWin *mw)
 	XMoveResizeWindow(ps->dpy, mw->window, iter->x_org, iter->y_org, mw->width, mw->height);
 
 	mw->xin_active = iter;
-	if (ps->o.xinerama_showAll)
+	if (!ps->o.showOnlyCurrentMonitor)
 		mw->xin_active = 0;
 #endif /* CFG_XINERAMA */
 	mainwin_update_background(mw);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -2758,8 +2758,7 @@ load_config_file(session_t *ps)
 			ps->o.updatetooltip = true;
 	}
 
-    config_get_bool_wrap(config, "filter", "showOnlyCurrentMonitor", &ps->o.xinerama_showAll);
-	ps->o.xinerama_showAll = !ps->o.xinerama_showAll;
+    config_get_bool_wrap(config, "filter", "showOnlyCurrentMonitor", &ps->o.showOnlyCurrentMonitor);
     config_get_bool_wrap(config, "filter", "showOnlyCurrentScreen", &ps->o.filterxscreen);
     config_get_bool_wrap(config, "filter", "showShadow", &ps->o.showShadow);
     config_get_bool_wrap(config, "filter", "showSticky", &ps->o.showSticky);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1192,10 +1192,6 @@ skippy_activate(MainWin *mw, enum layoutmode layout, Window leader)
 
 	// Update the main window's geometry (and Xinerama info if applicable)
 	mainwin_update(mw);
-#ifdef CFG_XINERAMA
-	if (ps->o.xinerama_showAll)
-		mw->xin_active = 0;
-#endif /* CFG_XINERAMA */
 
 	mw->client_to_focus = NULL;
 

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -264,7 +264,7 @@ typedef struct {
 	char *tooltip_font;
 	bool updatetooltip;
 
-	bool xinerama_showAll;
+	bool showOnlyCurrentMonitor;
 	bool filterxscreen;
 	bool showShadow;
 	bool showSticky;
@@ -317,7 +317,7 @@ typedef struct {
 	.distance = 50, \
 	.allowUpscale = false, \
 \
-	.xinerama_showAll = true, \
+	.showOnlyCurrentMonitor = false, \
 	.filterxscreen = true, \
 	.showShadow = true, \
 	.showSticky = true, \


### PR DESCRIPTION
The root cause of the bug on #339 is that when detecting whether a window is showing on a xinerama screen, the window coordinate before normalization is used.

The lifecycle of a window coordinate is raw window coordinates, then apply layout algorithm, after which window coordinates change. Depending on the layout algorithm, the window coordinates may become bigger than the screen width/height. Subsequent functions performs "normalization", so that window coordinates shrink to within the screen width/height.

Hence, the fix is to call the window coordinate normalization code before this check.

Also tidy up relevant code.