### PR TITLE
Fix showOnlyCurrentMonitor by introducing cw->src0

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -53,10 +53,8 @@ clientwin_filter_func(dlist *l, void *data) {
 	session_t *ps = mw->ps;
 
 #ifdef CFG_XINERAMA
-	clientwin_movecoord(cw, mw->multiplier, mw->xoff, mw->yoff, 1);
-
 	if (mw->xin_active && !INTERSECTS(
-			cw->src.x, cw->src.y, cw->src.width, cw->src.height,
+			cw->src0.x, cw->src0.y, cw->src0.width, cw->src0.height,
 			mw->xin_active->x_org, mw->xin_active->y_org,
 			mw->xin_active->width, mw->xin_active->height))
 		return false;
@@ -235,6 +233,10 @@ clientwin_update(ClientWin *cw) {
 
 	cw->src.width = wattr.width;
 	cw->src.height = wattr.height;
+	cw->src0.x = cw->src.x;
+	cw->src0.y = cw->src.y;
+	cw->src0.width = cw->src.width;
+	cw->src0.height = cw->src.height;
 
 	bool isViewable = wattr.map_state == IsViewable;
 	cw->zombie = !isViewable;
@@ -636,7 +638,7 @@ void clientwin_prepmove(ClientWin *cw)
 }
 
 void
-clientwin_movecoord(ClientWin *cw, float f, int x, int y, float timeslice)
+clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
 {
 	cw->factor = f;
 	{
@@ -649,12 +651,6 @@ clientwin_movecoord(ClientWin *cw, float f, int x, int y, float timeslice)
 		cw->mini.width = cw->src.width * f;
 		cw->mini.height = cw->src.height * f;
 	}
-}
-
-void
-clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
-{
-	clientwin_movecoord(cw, f, x, y, timeslice);
 
 	XMoveResizeWindow(cw->mainwin->ps->dpy, cw->mini.window,
 			cw->mini.x, cw->mini.y, cw->mini.width, cw->mini.height);

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -36,7 +36,7 @@ struct _clientwin_t {
 
 	client_disp_mode_t mode;
 	Window wid_client;
-	SkippyWindow src;
+	SkippyWindow src, src0;
 	bool redirected;
 	Pixmap cpixmap;
 	pictw_t *pict_filled;
@@ -96,7 +96,6 @@ int clientwin_sort_func(dlist *, dlist *, void *);
 ClientWin *clientwin_create(MainWin *, Window);
 void clientwin_destroy(ClientWin *, bool destroyed);
 void clientwin_prepmove(ClientWin *);
-void clientwin_movecoord(ClientWin *, float, int, int, float);
 void clientwin_move(ClientWin *, float, int, int, float);
 void clientwin_map(ClientWin *);
 void clientwin_unmap(ClientWin *);


### PR DESCRIPTION
#346 was wrong diagnosis and wrong fix for #339 :P

The root cause of the bug on showOnlyCurrentMonitor is that the windows original coordinates, in the case of paging, is already offset by the virtual desktop the window is sitting on, vs the current one.

Hence, with showOnlyCurrentMonitor = true, the check on the coordinates between window coordinates and xinerama screen coordinates are wrong.

Introduce a set of coordinates per window to store the coordinates before the virtual desktop offset.