### PR TITLE
Z-order scrambling fixed

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -863,7 +863,8 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 	if (first) {
 		mw->client_to_focus = first->data;
 		mw->client_to_focus->focused = 1;
-		if (iter && !mw->mapped)
+		if (iter && !mw->mapped &&
+				(ps->o.switchCycleDuringWait || ps->o.switchWaitDuration == 0))
 			childwin_focus(mw->client_to_focus);
 	}
 


### PR DESCRIPTION
One line of change, but lots of combinations of use cases and test cases:

| Use cases 1 | Use case 2 |
| -- | -- |
| Quick --switch --next | Long-hold --switch --next |
|Quick --switch --prev | Long-hold --switch --prev |
|Quick --expose --next | Long-hold --expose --next |
|Quick --expose --prev | Long-hold --expose --prev |

| Config | Value 1 | Value 2|
| -- | -- | -- |
| switchWaitDuration | 0 | 100 |

| Config | Value 1 | Value 2|
| -- | -- | -- |
| switchCycleDuringWait | false | true |

| Config | Value 1 | Value 2|
| -- | -- | -- |
| switchLayout | xd | cosmos |

| Config | Value 1 | Value 2|
| -- | -- | -- |
| exposeLayout | xd | cosmos |

Tested satisfactory to me.