### PR TITLE
Update client windows before performing window filtering

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -796,6 +796,34 @@ daemon_count_clients(MainWin *mw)
 {
 	update_clients(mw);
 
+	session_t *ps = mw->ps;
+	foreach_dlist (mw->clients) {
+		ClientWin *cw = (ClientWin *) iter->data;
+		XWindowAttributes wattr = { };
+		XGetWindowAttributes(ps->dpy, cw->src.window, &wattr);
+
+		{
+			Window tmpwin = None;
+			XTranslateCoordinates(ps->dpy, cw->src.window, wattr.root,
+					-wattr.border_width, -wattr.border_width,
+					&cw->src.x, &cw->src.y, &tmpwin);
+
+			if (wattr.width == 0 && wattr.height == 0) {
+				XGetWindowAttributes(ps->dpy, cw->wid_client, &wattr);
+				XTranslateCoordinates(ps->dpy, cw->wid_client, wattr.root,
+						-wattr.border_width, -wattr.border_width,
+						&cw->src.x, &cw->src.y, &tmpwin);
+			}
+		}
+
+		cw->src.width = wattr.width;
+		cw->src.height = wattr.height;
+		cw->src0.x = cw->src.x;
+		cw->src0.y = cw->src.y;
+		cw->src0.width = cw->src.width;
+		cw->src0.height = cw->src.height;
+	}
+
 	// update mw->clientondesktop
 	long desktop = wm_get_current_desktop(mw->ps);
 
@@ -1199,11 +1227,11 @@ skippy_activate(MainWin *mw, enum layoutmode layout, Window leader)
 
 	mw->client_to_focus = NULL;
 
+	daemon_count_clients(mw);
 	foreach_dlist(mw->clients) {
 		clientwin_update((ClientWin *) iter->data);
 		clientwin_update2((ClientWin *) iter->data);
 	}
-	daemon_count_clients(mw);
 
 	if (layout == LAYOUTMODE_PAGING) {
 		if (!init_paging_layout(mw, layout, leader)) {


### PR DESCRIPTION
Some users have reported window filtering/current monitor filteirng being incorrect. I myself *might* have reproduced it 1-2 times.

Notably, one user can reproduce incorrect filtering with `skippy-xd --expose`, but not with `skippy-xd`.

From code inspection, perhaps:

In `skippy-xd`, skippy_activate() is called right after
```
daemon_count_clients(mw);
foreach_dlist(mw->clients) {
    clientwin_update((ClientWin *) iter->data);
    clientwin_update2((ClientWin *) iter->data);
}
```

whereas for `skippy-xd --expose` the update sequence is not guaranteed.

Then, in skippy_activate(), we have the above daemon_count_clients() then foreach update block again.

Filtering is performed *within* daemon_count_clients(). Hence, for `skippy-xd --expose`, skippy_activate() may use stale window data for window filtering, and then perform windows update.

This hypothesis would account for non-deterministic/state dependent filtering bug.

The fix would of course be to perform windows update *before* window filtering.