### PR TITLE
Free filler resources on clientwin_update3()

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -258,6 +258,8 @@ bool
 clientwin_update3(ClientWin *cw) {
 	session_t *ps = cw->mainwin->ps;
 
+	clientwin_free_res2(ps, cw);
+
 	XWindowAttributes wattr = { };
 	XGetWindowAttributes(ps->dpy, cw->src.window, &wattr);
 	bool isViewable = wattr.map_state == IsViewable;


### PR DESCRIPTION
Silly me...

#391 divided clientwin_update() into clientwin_update() and clientwin_update3(). This introduced #413, which is fixed in #421, which removed clientwin_free_res2() in clientwin_update().

The removal of clientwin_free_res2() leads to resource leak of filler windows. The appropriate thing to do is to introduce clientwin_free_res2() into clientwin_update3().

The impact of the resource leak was very small, as the leak size was small, and filler windows tend not to be long lived.