### PR TITLE
Eliminate X error when unmapped window is selected

### DIFF
--- a/src/wm.h
+++ b/src/wm.h
@@ -170,7 +170,8 @@ wm_activate_window(session_t *ps, Window wid) {
 
 	// Order is important, to avoid "intelligent" WMs fixing our focus stealing
 	wm_activate_window_ewmh(ps, wid);
-	//XSetInputFocus(ps->dpy, wid, RevertToParent, CurrentTime);
+	usleep(10000);
+	XSetInputFocus(ps->dpy, wid, RevertToParent, CurrentTime);
 }
 
 Window wm_find_frame(session_t *ps, Window wid);


### PR DESCRIPTION
This needs careful testing from plenty of environments, as it is changing window selection to not perform input focus. For my testing it works completely fine, but it may well be some environments this messes up window selection.