### PR TITLE
Tidy code and introduce frame offset

### DIFF
--- a/skippy-xd.rc
+++ b/skippy-xd.rc
@@ -100,6 +100,11 @@ preservePages = true
 # Whether to display window frames
 includeFrame = true
 
+# Depending on your environment and window frame,
+# Introduce pixel offsets for better alignment
+leftFrameBorder = 0
+topFrameBorder = 0
+
 # Show window previews with rounded corners
 cornerRadius = 0
 

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -708,26 +708,23 @@ void clientwin_prepmove(ClientWin *cw)
 void
 clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
 {
-	cw->factor = f;
-	{
-		// animate window by changing these in time linearly:
-		// here, cw->mini has destination coordinates, cw->src has original coordinates
-		MainWin *mw = cw->mainwin;
-		session_t *ps = mw->ps;
+	MainWin *mw = cw->mainwin;
+	session_t *ps = mw->ps;
 
-		cw->mini.x = cw->src.x + (cw->x - cw->src.x + x) * timeslice;
-		cw->mini.y = cw->src.y + (cw->y - cw->src.y + y) * timeslice;
-		if (!ps->o.pseudoTrans) {
-			cw->mini.x += mw->x;
-			cw->mini.y += mw->y;
-		}
-
-		cw->mini.width = cw->src.width * f;
-		cw->mini.height = cw->src.height * f;
+	cw->mini.x = cw->src.x + (cw->x - cw->src.x + x) * timeslice;
+	cw->mini.y = cw->src.y + (cw->y - cw->src.y + y) * timeslice;
+	if (!ps->o.pseudoTrans) {
+		cw->mini.x += mw->x;
+		cw->mini.y += mw->y;
 	}
 
+	cw->factor = f;
+	cw->mini.width = cw->src.width * f;
+	cw->mini.height = cw->src.height * f;
+
 	XMoveResizeWindow(cw->mainwin->ps->dpy, cw->mini.window,
-			cw->mini.x, cw->mini.y, cw->mini.width, cw->mini.height);
+			cw->mini.x + ps->o.leftFrameBorder, cw->mini.y + ps->o.topFrameBorder,
+			cw->mini.width, cw->mini.height);
 
 	if (cw->paneltype == WINTYPE_WINDOW)
 		clientwin_round_corners(cw);

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -502,12 +502,18 @@ clientwin_repaint(ClientWin *cw, const XRectangle *pbound)
 			foreach_dlist (mw->dminis) {
 				ClientWin *dwin = (ClientWin *) iter->data;
 
+				int leftborder = 0, topborder = 0;
+				if (wm_get_fullscreen(ps, cw->wid_client)) {
+					leftborder = ps->o.leftFrameBorder;
+					topborder = ps->o.topFrameBorder;
+				}
+
 #ifdef CFG_XINERAMA
 				XineramaScreenInfo *iter = mw->xin_info;
 				for (int i = 0; i < mw->xin_screens; ++i)
 				{
-					int x = dwin->x + iter->x_org + mw->xoff - cw->src.x + mw->x;
-					int y = dwin->y + iter->y_org + mw->yoff - cw->src.y + mw->y;
+					int x = dwin->x + iter->x_org + mw->xoff - cw->src.x + mw->x + leftborder;
+					int y = dwin->y + iter->y_org + mw->yoff - cw->src.y + mw->y + topborder;
 					int width = iter->width * mw->multiplier;
 					int height = iter->height * mw->multiplier;
 
@@ -518,8 +524,8 @@ clientwin_repaint(ClientWin *cw, const XRectangle *pbound)
 					iter++;
 				}
 #else
-				int x = dwin->x + mw->xoff - cw->src.x + mw->x;
-				int y = dwin->y + mw->yoff - cw->src.y + mw->y;
+				int x = dwin->x + mw->xoff - cw->src.x + mw->x + leftborder;
+				int y = dwin->y + mw->yoff - cw->src.y + mw->y topborder;
 				int width = dwin->src.width * mw->multiplier;
 				int height = dwin->src.height * mw->multiplier;
 
@@ -722,8 +728,11 @@ clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
 	cw->mini.width = cw->src.width * f;
 	cw->mini.height = cw->src.height * f;
 
+	int leftborder = ps->o.leftFrameBorder, topborder = ps->o.topFrameBorder;
+	if (wm_get_fullscreen(ps, cw->wid_client))
+		leftborder = topborder = 0;
 	XMoveResizeWindow(cw->mainwin->ps->dpy, cw->mini.window,
-			cw->mini.x + ps->o.leftFrameBorder, cw->mini.y + ps->o.topFrameBorder,
+			cw->mini.x + leftborder, cw->mini.y + topborder,
 			cw->mini.width, cw->mini.height);
 
 	if (cw->paneltype == WINTYPE_WINDOW)

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -525,7 +525,7 @@ clientwin_repaint(ClientWin *cw, const XRectangle *pbound)
 				}
 #else
 				int x = dwin->x + mw->xoff - cw->src.x + mw->x + leftborder;
-				int y = dwin->y + mw->yoff - cw->src.y + mw->y topborder;
+				int y = dwin->y + mw->yoff - cw->src.y + mw->y + topborder;
 				int width = dwin->src.width * mw->multiplier;
 				int height = dwin->src.height * mw->multiplier;
 

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -249,8 +249,8 @@ clientwin_update(ClientWin *cw) {
 
 	cw->src.width = wattr.width;
 	cw->src.height = wattr.height;
-	cw->src0.x = cw->src.x;
-	cw->src0.y = cw->src.y;
+	cw->x = cw->src0.x = cw->src.x;
+	cw->y = cw->src0.y = cw->src.y;
 	cw->src0.width = cw->src.width;
 	cw->src0.height = cw->src.height;
 
@@ -729,7 +729,8 @@ clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
 	XMoveResizeWindow(cw->mainwin->ps->dpy, cw->mini.window,
 			cw->mini.x, cw->mini.y, cw->mini.width, cw->mini.height);
 
-	clientwin_round_corners(cw);
+	if (cw->paneltype == WINTYPE_WINDOW)
+		clientwin_round_corners(cw);
 }
 
 void

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -870,7 +870,6 @@ shadow_clientwindow(ClientWin* cw, enum cliop op) {
 	clientwin_update3(cw);
 
 	clientwin_prepmove(cw);
-	clientwin_move(cw, mw->multiplier, mw->xoff, mw->yoff, 1);
 	clientwin_map(cw);
 
 	focus_miniw(ps, cw);

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -226,14 +226,10 @@ clientwin_get_disp_mode(session_t *ps, ClientWin *cw, bool isViewable) {
 	return CLIDISP_NONE;
 }
 
-/**
- * @brief Update window data to prepare for rendering.
- */
 bool
 clientwin_update(ClientWin *cw) {
 	session_t *ps = cw->mainwin->ps;
 
-	// Get window attributes
 	XWindowAttributes wattr = { };
 	XGetWindowAttributes(ps->dpy, cw->src.window, &wattr);
 

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -81,15 +81,6 @@ clientwin_free_res2(session_t *ps, ClientWin *cw) {
 	free_pictw(ps, &cw->pict_filled);
 }
 
-static inline void
-clientwin_free_res(session_t *ps, ClientWin *cw) {
-	clientwin_free_res2(ps, cw);
-	free_pixmap(ps, &cw->cpixmap);
-	free_picture(ps, &cw->origin);
-	free_pictw(ps, &cw->icon_pict);
-	free_pictw(ps, &cw->icon_pict_filler);
-}
-
 int clientwin_validate_panel(dlist *, void *);
 int clientwin_filter_func(dlist *, void *);
 int clientwin_sort_func(dlist *, dlist *, void *);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1629,8 +1629,10 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 							XRoundedRectComposite(mw->ps,
 									mw->ps->o.from, mw->background,
-									s_x + mw->xoff + mw->x, s_y + mw->yoff + mw->y,
-									s_x + mw->xoff, s_y + mw->yoff,
+									s_x + mw->xoff + mw->x + ps->o.leftFrameBorder,
+									s_y + mw->yoff + mw->y + ps->o.topFrameBorder,
+									s_x + mw->xoff + ps->o.leftFrameBorder,
+									s_y + mw->yoff + ps->o.topFrameBorder,
 									s_w,
 									s_h,
 									ps->o.cornerRadius * mw->multiplier);
@@ -1639,8 +1641,10 @@ mainloop(session_t *ps, bool activate_on_start) {
 #else
 						XRoundedRectComposite(mw->ps,
 								mw->ps->o.from, mw->background,
-								cw->x + mw->xoff + mw->x, cw->y + mw->yoff + mw->y,
-								cw->x + mw->xoff, cw->y + mw->yoff,
+								cw->x + mw->xoff + mw->x + ps->o.leftFrameBorder,
+								cw->y + mw->yoff + mw->y + ps->o.topFrameBorder,
+								cw->x + mw->xoff + ps->o.leftFrameBorder,
+								cw->y + mw->yoff + ps->o.topFrameBorder,
 								cw->src.width * mw->multiplier,
 								cw->src.height * mw->multiplier,
 								ps->o.cornerRadius * mw->multiplier);
@@ -2769,7 +2773,9 @@ load_config_file(session_t *ps)
 	config_get_bool_wrap(config, "appearance", "preservePages", &ps->o.preservePages);
     config_get_bool_wrap(config, "bindings", "moveMouse", &ps->o.moveMouse);
     config_get_bool_wrap(config, "appearance", "includeFrame", &ps->o.includeFrame);
-	config_get_int_wrap(config, "appearance", "cornerRadius", &ps->o.cornerRadius, 0, INT_MAX);
+	config_get_int_wrap(config, "appearance", "leftFrameBorder", &ps->o.leftFrameBorder, 0, 100);
+	config_get_int_wrap(config, "appearance", "topFrameBorder", &ps->o.topFrameBorder, 0, 100);
+	config_get_int_wrap(config, "appearance", "cornerRadius", &ps->o.cornerRadius, 0, 100);
     {
         static client_disp_mode_t DEF_CLIDISPM[] = {
             CLIDISP_THUMBNAIL, CLIDISP_ZOMBIE, CLIDISP_ICON, CLIDISP_FILLED, CLIDISP_NONE

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1279,7 +1279,6 @@ skippy_activate(MainWin *mw, enum layoutmode layout, Window leader)
 
 	count_and_filter_clients(mw);
 	foreach_dlist(mw->clients) {
-		clientwin_update((ClientWin *) iter->data);
 		clientwin_update3((ClientWin *) iter->data);
 		clientwin_update2((ClientWin *) iter->data);
 	}
@@ -1389,7 +1388,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 	count_and_filter_clients(ps->mainwin);
 
 	foreach_dlist(ps->mainwin->clients) {
-		clientwin_update((ClientWin *) iter->data);
 		clientwin_update3((ClientWin *) iter->data);
 		clientwin_update2((ClientWin *) iter->data);
 	}
@@ -1788,7 +1786,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 				dlist *iter = (wid ? dlist_find(ps->mainwin->clients, clientwin_cmp_func, (void *) wid): NULL);
 				if (iter) {
 					ClientWin *cw = (ClientWin *) iter->data;
-					clientwin_update(cw);
 					clientwin_update3(cw);
 					clientwin_update2(cw);
 				}
@@ -1812,7 +1809,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 								clientwin_cmp_func, (void *) wid): NULL);
 						if (iter) {
 							ClientWin *cw = (ClientWin *) iter->data;
-							clientwin_update(cw);
 							clientwin_update3(cw);
 							clientwin_update2(cw);
 						}

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1296,6 +1296,8 @@ skippy_activate(MainWin *mw, enum layoutmode layout, Window leader)
 
 	foreach_dlist(mw->clientondesktop) {
 		ClientWin *cw = iter->data;
+		cw->src.x -= mw->x;
+		cw->src.y -= mw->y;
 		cw->x *= mw->multiplier;
 		cw->y *= mw->multiplier;
 		cw->paneltype = WINTYPE_WINDOW;

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -227,6 +227,8 @@ typedef struct {
 	bool preservePages;
 	bool moveMouse;
 	bool includeFrame;
+	int leftFrameBorder;
+	int topFrameBorder;
 	int cornerRadius;
 	client_disp_mode_t *clientDisplayModes;
 	pictspec_t iconSpec;
@@ -319,6 +321,8 @@ typedef struct {
 	.preservePages = true, \
 	.moveMouse = false, \
 	.includeFrame = false, \
+	.leftFrameBorder = 0, \
+	.topFrameBorder = 0, \
 	.cornerRadius = 0, \
 	.clientDisplayModes = NULL, \
 	.iconSpec = PICTSPECT_INIT, \

--- a/src/wm.c
+++ b/src/wm.c
@@ -637,6 +637,31 @@ wm_get_group_leader(Display *dpy, Window window)
 	return leader;
 }
 
+bool wm_get_fullscreen(session_t *ps, Window window) {
+	Atom actualType;
+	int actualFormat;
+	unsigned long numItems, bytesAfter;
+	Atom *atoms = NULL;
+
+	if (XGetWindowProperty(ps->dpy, window,
+			get_atom(ps, "_NET_WM_STATE"), 0, (~0L),
+			False, AnyPropertyType,
+			&actualType, &actualFormat,
+			&numItems, &bytesAfter,
+			(unsigned char**)&atoms) != Success)
+		return false;
+
+	bool fullscreen = false;
+	for (unsigned long i = 0; i < numItems; i++)
+		if (atoms[i] == get_atom(ps, "_NET_WM_STATE_FULLSCREEN")) {
+			fullscreen = true;
+			break;
+		}
+
+	if (atoms) XFree(atoms);
+	return fullscreen;
+}
+
 void
 wm_set_fullscreen(session_t *ps, Window window,
 		int x, int y, unsigned width, unsigned height) {

--- a/src/wm.h
+++ b/src/wm.h
@@ -90,8 +90,10 @@ FcChar8 *wm_get_window_title(session_t *ps, Window wid, int *length_return);
 FcChar8 *wm_get_desktop_name(session_t *ps, int desktop);
 void printfdfWindowName(session_t *ps, char *prefix_str, Window wid);
 Window wm_get_group_leader(Display *dpy, Window window);
+bool wm_get_fullscreen(session_t *ps, Window window);
 void wm_set_fullscreen(session_t *ps, Window window,
 		int x, int y, unsigned width, unsigned height);
+
 wintype_t wm_identify_panel(session_t *ps, Window wid);
 bool wm_validate_window(session_t *ps, Window wid);
 long wm_get_window_desktop(session_t *ps, Window wid);


### PR DESCRIPTION
This is a moderate sized PR that does two main things:

A. Tidy up code while keeping all behaviour unchanged.

One function is never used and removed.

Panel and desktop windows coordinate calculations are hugely simplified, and now calls the same functions as normal windows. This is hugely advantageous for these reasons:
1. Code reuse follows DRY principle
2. pseudoTrans specific coordinate calculation is now centralized to only one piece of code. Code/config fragmentation is much reduced. This is especially advantageous if/when we extend multi-monitor features.
3. General code readability is much reduced for panel and desktop windows
4. Another function is no longer used and removed

B. Given now window coordinate calculations is much clearer, I added config options `appearance/leftFrameBorder`, `appearance/rightFrameBorder`.

Depending on the environment, the window frame may be slightly offset by a few pixels. The new config options allow the user to offset this perfectly.

Fullscreen windows do not have window frames, so the offsets are not applied.