### PR TITLE
CreateNotify, MapNotify processing greatly optimized

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1784,14 +1784,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 					clientwin_update3(cw);
 					clientwin_update2(cw);
 					cw->damaged = true;
-
-					if (cw->origin && cw->paneltype == WINTYPE_WINDOW)
-						XRenderSetPictureTransform(ps->dpy,
-								cw->origin, &cw->mainwin->transform);
-
-					if (cw->shadow && cw->paneltype == WINTYPE_WINDOW)
-						XRenderSetPictureTransform(ps->dpy,
-								cw->shadow, &cw->mainwin->transform);
 				}
 				num_events--;
 
@@ -1800,25 +1792,23 @@ mainloop(session_t *ps, bool activate_on_start) {
 					while(num_events > 0)
 					{
 						XPeekEvent(ps->dpy, &ev_next);
-
 						if (ev_next.type != CreateNotify && ev_next.type != MapNotify
 						 && ev_next.type != VisibilityNotify && ev_next.type != ConfigureNotify
 						 && ev_next.type != PropertyNotify && ev_next.type != Expose
 						 && ev_next.type != FocusIn && ev_next.type != FocusOut
 						 && ev_next.type != UnmapNotify && ev_next.type != ReparentNotify
-						 && ev_next.type != ps->xinfo.damage_ev_base + XDamageNotify) {
+						 && ev_next.type != ps->xinfo.damage_ev_base + XDamageNotify)
 							break;
-						}
 
 						XNextEvent(ps->dpy, &ev);
 						wid = ev_window(ps, &ev);
+						num_events--;
 
 						if (ev.type == FocusOut)
 							focus_stolen = true;
 						if (ev.type == FocusIn)
 							focus_stolen = false;
 
-						num_events--;
 						dlist *iter = (wid ? dlist_find(ps->mainwin->clients,
 								clientwin_cmp_func, (void *) wid): NULL);
 						if (iter) {


### PR DESCRIPTION
When creating a window, many X events are generated. In my environment, hundreds of events.

This PR optimizes the X events handling so all these events are processed in an optimal way, improving code cleanliness and theoretical performance...

That said, I don't fully understand how all these X events and handling work, I think there is some risk when creating/mapping lots of windows very quickly.

Everything is perfect to my testing, but still not 100% comfortable.