### PR TITLE
Process KeymapNotify, MappingNotify immediately

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1793,6 +1793,17 @@ mainloop(session_t *ps, bool activate_on_start) {
 					while(num_events > 0)
 					{
 						XPeekEvent(ps->dpy, &ev_next);
+
+						// these events have to be handled promptly
+						// otherwise race condition may
+						// non-deterministically lead to broken state
+						if (ev_next.type == KeymapNotify || ev_next.type == MappingNotify) {
+							XNextEvent(ps->dpy, &ev);
+							XRefreshKeyboardMapping(&ev.xmapping);
+							num_events--;
+							continue;
+						}
+
 						if (ev_next.type != CreateNotify && ev_next.type != MapNotify
 						 && ev_next.type != VisibilityNotify && ev_next.type != ConfigureNotify
 						 && ev_next.type != PropertyNotify && ev_next.type != Expose


### PR DESCRIPTION
I noticed a horrible bug recent days:

Paging ignores keyboard presses, up/down/left/right/next/prev, unless the mouse is on top of one of the "pages".

I am guessing #441 was the culprit: it optimizes window creation events by batch processing them. Perhaps by batch processing X events, some states got messed up and hence keyboard events on the skippy-xd fullscreen window (but not other skippy-xd windows) got ignored.

This hypothesis is confirmed by ChatGPT, who says KeymapNotify and MappingNotify needs to be processed immediately with XRefreshKeyboardMapping(), and we arrived at the code fix.

So far this looks good to my testing.

This is exactly the kind of bugs I am wary of, with the kind of PRs I am doing. Happens rarely, non-deterministic, and leads to horrible user experience. And you don't even know if the fix is actually good or not.

Thankfully the strategic slow PR merges have made localizing bugs a bit easier.