### PR TITLE
Fix alt-tab tinting bug

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -2157,9 +2157,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 						ps->o.focus_initial--;
 					}
 					ps->o.focus_initial = oldfocus;
-
-					if (mw->client_to_focus)
-						clientwin_render(mw->client_to_focus);
 				}
 
 				// if the client did not trigger activation, return to it immediately


### PR DESCRIPTION
This PR fixes a bug introduced in #446. Prior to #446, a window is always repainted during focus change; when there is only one window in selection, the only window is still repainted, leading to flickers. #446 eliminates the flicker by repainting a window only when the the focus out/focus in windows are different.

However, it introduced this bug, which, together with the code fix, is deceptively complicated.

The bug:
 1. `system/pseudoTrans = false`
 2. alt-tab where the window list has only one window
 3. *only when* the mouse hoovers above the window
 4. after alt-tab activation, alt-tab again leads to the only window being un-highlighted
 5. expose and then `n` does not trigger this bug

This is a complex bug with simple consequence.

Point 5. is simple to understand. The code path is specific to `--next` command line parameter.

Point 2. is simple to understand. When there is more than one window, the focus out/focus in windows are different, so both will be repainted properly. When there is only one window, with PR #446, we will NOT repaint the window.

Somehow, when the mouse hoovers the window, and (in hindsight) a window repaint, and with true transparency, the focus state of the window will be set to false, leading to the window being un-highlighted.

I think the repainting of the window, together with the mouse hoovering, lead to interactions in X11, triggering focus in/focus out events, ultimately setting the only window to be "unfocused", losing the highlight tint. And, transparency/picom is also at play. It is a very complex and mysterious interaction between repainting, mouse focus, and compositing that results in this bug.

Previous code in focus_miniw_next() masked this bug by always focusing back to the current window, at the expense of the flicker. #446 eliminated the flicker, but surfaced the bug.

This is a good learning lesson about the complexity and potential perils of X11.