### PR TITLE
Tighten focus enforcement

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1793,17 +1793,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 					while(num_events > 0)
 					{
 						XPeekEvent(ps->dpy, &ev_next);
-
-						// these events have to be handled promptly
-						// otherwise race condition may
-						// non-deterministically lead to broken state
-						if (ev_next.type == KeymapNotify || ev_next.type == MappingNotify) {
-							XNextEvent(ps->dpy, &ev);
-							XRefreshKeyboardMapping(&ev.xmapping);
-							num_events--;
-							continue;
-						}
-
 						if (ev_next.type != CreateNotify && ev_next.type != MapNotify
 						 && ev_next.type != VisibilityNotify && ev_next.type != ConfigureNotify
 						 && ev_next.type != PropertyNotify && ev_next.type != Expose


### PR DESCRIPTION
I rethought #450. I think the diagnosis and fix #448 is not correct.

Probably, the root cause is due to focus being stolen, as a long standing edge case, and my recent setup exposed it relatively often.

This PR reverts #448, and tightens focus enforcement.