### PR TITLE
Alignment config values top/mid/bottom

### DIFF
--- a/skippy-xd.rc
+++ b/skippy-xd.rc
@@ -107,14 +107,14 @@ cornerRadius = 0
 [filler]
 opacity = 160
 color = #333333
-iconPlace = left left
+iconPlace = top left
 iconSize = 48
 
 # Live window previews
 [livepreview]
 opacity = 255
 icon = true
-iconPlace = left left
+iconPlace = top left
 iconSize = 48
 
 # Currently highlighted window

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -342,8 +342,8 @@ parse_pictspec(session_t *ps, const char *s, pictspec_t *dest) {
 	if (!(next = parse_pict_posp_mode(ps, s, &dest->mode)))
 		dest->mode = PICTPOSP_ORIG;
 	T_NEXTFIELD();
-	if (!(next = parse_align(ps, s, &dest->alg))) {
-		dest->alg = ALIGN_MID;
+	if (!(next = parse_alignv(ps, s, &dest->valg))) {
+		dest->valg = ALIGN_LEFT;
 		// set next increment to next space separated word
 		while (!isspace(*(s + next)))
 			next++;
@@ -351,8 +351,8 @@ parse_pictspec(session_t *ps, const char *s, pictspec_t *dest) {
 			next++;
 	}
 	T_NEXTFIELD();
-	if (!(next && (next = parse_alignv(ps, s, &dest->valg)))) {
-		dest->valg = ALIGN_MID;
+	if (!(next = parse_align(ps, s, &dest->alg))) {
+		dest->alg = ALIGN_LEFT;
 		// set next increment to next space separated word
 		while (!isspace(*(s + next)))
 			next++;
@@ -2759,7 +2759,7 @@ load_config_file(session_t *ps)
         const char *sspec = config_get(config, "appearance", "background", "#00000055");
 		if (!sspec || strlen(sspec) == 0)
 			sspec = "#00000055";
-		char bg_spec[256] = "orig mid mid ";
+		char bg_spec[256] = "orig top left ";
 		strcat(bg_spec, sspec);
 
 		pictspec_t spec = PICTSPECT_INIT;
@@ -2800,7 +2800,7 @@ load_config_file(session_t *ps)
     }
 	{
 		char defaultstr2[256] = "orig ";
-		const char* sspec2 = config_get(config, "livepreview", "iconPlace", "left left");
+		const char* sspec2 = config_get(config, "livepreview", "iconPlace", "top left");
 		strcat(defaultstr2, sspec2);
 		const char space[] = " ";
 		strcat(defaultstr2, space);
@@ -2822,14 +2822,14 @@ load_config_file(session_t *ps)
 			return RET_BADARG;
 }
 	{
-		char defaultstr[256] = "orig mid mid ";
+		char defaultstr[256] = "orig top left ";
 		const char* sspec = config_get(config, "filler", "color", "#333333");
 		strcat(defaultstr, sspec);
 		if (!parse_pictspec(ps, defaultstr, &ps->o.fillSpec))
 			return RET_BADARG;
 
 		char defaultstr2[256] = "orig ";
-		const char* sspec2 = config_get(config, "filler", "iconPlace", "mid mid");
+		const char* sspec2 = config_get(config, "filler", "iconPlace", "top left");
 		strcat(defaultstr2, sspec2);
 		const char space[] = " ";
 		strcat(defaultstr2, space);


### PR DESCRIPTION
Config value `Alignment` now takes `top` `mid` `bottom` in addition to `left` `mid` `right`.

More concretely, this lines
```
iconPlace = left left
```
now becomes
```
iconPlace = top left
```
which is obviously a bit more descriptive.

In addition, in case of config file parsing error, the app handles it gracefully with default value rather than terminate.