### PR TITLE
Add GitHub Actions workflow to build and publish AppImage + Deb files ( 64bit + 32bit ) + Rpm

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,277 @@
+# -----------------------------------------------------------------------------
+# Skippy-XD AppImage Builder — GitHub Actions Workflow
+# Triggers: on every tagged release (v*) and manual dispatch
+# Produces:  Skippy-xd-<version>-x86_64.AppImage attached to the GitHub Release
+# -----------------------------------------------------------------------------
+
+name: Build AppImage
+
+on:
+  push:
+    tags:
+      - 'v*'                        # fires on v0.10.6, v1.0.0, etc.
+  workflow_dispatch:                # allows manual trigger from Actions tab
+
+permissions:
+  contents: write                   # needed to upload to GitHub Releases
+
+jobs:
+  build-appimage:
+    runs-on: ubuntu-22.04           # oldest still-supported LTS — AppImageHub requirement
+
+    steps:
+
+      # -----------------------------------------------------------------------
+      # 1. Checkout
+      # -----------------------------------------------------------------------
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0            # full history so version.txt is always present
+
+      # -----------------------------------------------------------------------
+      # 2. Read version from version.txt (pure bash — no awk/sed issues)
+      # -----------------------------------------------------------------------
+      - name: Read version
+        id: version
+        run: |
+          read -r raw < version.txt
+          raw="${raw%% *}"          # strip everything after first space
+          VERSION="${raw#v}"        # strip leading 'v'
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: could not parse version from version.txt"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      # -----------------------------------------------------------------------
+      # 3. Install build dependencies
+      #    Targeting Ubuntu 22.04 Jammy baseline for maximum compatibility
+      # -----------------------------------------------------------------------
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            build-essential pkg-config wget \
+            libx11-dev libxft-dev libxrender-dev \
+            libxcomposite-dev libxdamage-dev libxfixes-dev \
+            libxext-dev libxinerama-dev \
+            libpng-dev zlib1g-dev libjpeg-dev libgif-dev \
+            libfreetype6-dev \
+            desktop-file-utils appstream \
+            libfuse2
+
+      # -----------------------------------------------------------------------
+      # 4. Build skippy-xd
+      #    Pass clean VERSION so man page sed substitution never breaks
+      # -----------------------------------------------------------------------
+      - name: Build
+        run: |
+          make PREFIX=/usr VERSION_SKIPPYXD="${{ steps.version.outputs.VERSION }}"
+
+      # -----------------------------------------------------------------------
+      # 5. Assemble AppDir
+      # -----------------------------------------------------------------------
+      - name: Assemble AppDir
+        run: |
+          APP="skippy-xd.AppDir"
+
+          mkdir -p \
+            "$APP/usr/bin" \
+            "$APP/usr/lib" \
+            "$APP/usr/share/man/man1" \
+            "$APP/usr/share/applications" \
+            "$APP/usr/share/icons/hicolor/256x256/apps" \
+            "$APP/usr/share/metainfo" \
+            "$APP/etc/xdg"
+
+          # Install binary, man page and rc via make install
+          make PREFIX=/usr DESTDIR="$(pwd)/$APP" install
+
+          chmod +x "$APP/usr/bin/skippy-xd"
+
+      # -----------------------------------------------------------------------
+      # 6. AppRun
+      # -----------------------------------------------------------------------
+      - name: Create AppRun
+        run: |
+          cat > skippy-xd.AppDir/AppRun << 'APPRUN_EOF'
+          #!/bin/bash
+          HERE="$(dirname "$(readlink -f "${0}")")"
+          export PATH="${HERE}/usr/bin:${PATH}"
+          export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH}"
+          export XDG_CONFIG_DIRS="${HERE}/etc/xdg:${XDG_CONFIG_DIRS}"
+          export XDG_DATA_DIRS="${HERE}/usr/share:${XDG_DATA_DIRS}"
+
+          if [ "$1" = "--help-man" ]; then
+            for MP in \
+              "${HERE}/usr/share/man/man1/skippy-xd.1.gz" \
+              "${HERE}/usr/share/man/man1/skippy-xd.1"; do
+              [ -f "$MP" ] || continue
+              [[ "$MP" == *.gz ]] && zcat "$MP" | man -l - || man -l "$MP"
+              exit $?
+            done
+            echo "Error: Manpage not found"; exit 1
+          fi
+
+          exec "${HERE}/usr/bin/skippy-xd" "$@"
+          APPRUN_EOF
+          chmod +x skippy-xd.AppDir/AppRun
+
+      # -----------------------------------------------------------------------
+      # 7. Desktop file
+      #    NoDisplay=true — skippy-xd is a daemon, not a menu app
+      # -----------------------------------------------------------------------
+      - name: Create desktop file
+        run: |
+          cat > skippy-xd.AppDir/skippy-xd.desktop << 'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=Skippy-XD
+          GenericName=Window Switcher
+          Comment=Expose-style window switcher daemon for X11
+          Exec=skippy-xd --start-daemon
+          Icon=skippy-xd
+          Terminal=false
+          Categories=Utility;X-Daemon;
+          Keywords=expose;window;switcher;daemon;x11;
+          NoDisplay=true
+          EOF
+
+          cp skippy-xd.AppDir/skippy-xd.desktop \
+             skippy-xd.AppDir/usr/share/applications/skippy-xd.desktop
+
+          desktop-file-validate skippy-xd.AppDir/skippy-xd.desktop \
+            && echo "Desktop file: OK"
+
+      # -----------------------------------------------------------------------
+      # 8. Icon — generate a real 256x256 PNG via Python (no extra deps)
+      # -----------------------------------------------------------------------
+      - name: Generate icon
+        run: |
+          python3 - << 'PYEOF'
+          import struct, zlib
+
+          def write_png(filename, size=256):
+              margin    = size // 8
+              thickness = max(size // 12, 3)
+              fg = (160, 160, 160)
+              bg = (30,  30,  30)
+              rows = []
+              for y in range(size):
+                  row = bytearray([0])          # filter byte: None
+                  for x in range(size):
+                      cx, cy   = size // 2, size // 2
+                      in_m     = margin <= x <= size-margin and margin <= y <= size-margin
+                      on_diag  = in_m and (abs(x-y) < thickness or abs(x-(size-1-y)) < thickness)
+                      dist     = ((x-cx)**2 + (y-cy)**2) ** 0.5
+                      on_ring  = abs(dist - (size//2 - margin//2)) < thickness
+                      row     += bytes(fg if (on_diag or on_ring) else bg)
+                  rows.append(bytes(row))
+
+              def chunk(tag, data):
+                  crc = zlib.crc32(tag + data) & 0xffffffff
+                  return struct.pack('>I', len(data)) + tag + data + struct.pack('>I', crc)
+
+              with open(filename, 'wb') as f:
+                  f.write(b'\x89PNG\r\n\x1a\n')
+                  f.write(chunk(b'IHDR', struct.pack('>II', size, size) + bytes([8,2,0,0,0])))
+                  f.write(chunk(b'IDAT', zlib.compress(b''.join(rows), 9)))
+                  f.write(chunk(b'IEND', b''))
+
+          write_png('skippy-xd.AppDir/skippy-xd.png')
+          write_png('skippy-xd.AppDir/usr/share/icons/hicolor/256x256/apps/skippy-xd.png')
+          print("Icon: OK")
+          PYEOF
+
+      # -----------------------------------------------------------------------
+      # 9. AppStream metainfo
+      #    Filename MUST match component <id> exactly — appstreamcli requirement
+      # -----------------------------------------------------------------------
+      - name: Create AppStream metainfo
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          DATE="$(date +%Y-%m-%d)"
+
+          cat > "skippy-xd.AppDir/usr/share/metainfo/io.github.felixfung.skippy-xd.appdata.xml" << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <component type="console-application">
+            <id>io.github.felixfung.skippy-xd</id>
+            <name>Skippy-XD</name>
+            <summary>Exposé-style window switcher daemon for X11</summary>
+            <metadata_license>FSFAP</metadata_license>
+            <project_license>GPL-2.0-or-later</project_license>
+            <description>
+              <p>
+                Skippy-XD is a full-screen Exposé-like task switcher for the X Window System.
+                It runs as a lightweight daemon and displays all open windows simultaneously,
+                allowing fast switching between them. Designed for minimal window managers
+                that do not provide their own expose functionality.
+              </p>
+              <p>
+                As a daemon, skippy-xd has no persistent graphical interface —
+                it activates on demand via a configurable hotkey or command.
+              </p>
+            </description>
+            <url type="homepage">https://github.com/felixfung/skippy-xd</url>
+            <url type="bugtracker">https://github.com/felixfung/skippy-xd/issues</url>
+            <developer id="io.github.felixfung">
+              <name>felixfung</name>
+            </developer>
+            <releases>
+              <release version="${VERSION}" date="${DATE}"/>
+            </releases>
+            <provides>
+              <binary>skippy-xd</binary>
+            </provides>
+            <categories>
+              <category>Utility</category>
+            </categories>
+            <content_rating type="oars-1.1"/>
+          </component>
+          EOF
+
+          appstreamcli validate --no-net \
+            "skippy-xd.AppDir/usr/share/metainfo/io.github.felixfung.skippy-xd.appdata.xml" \
+            && echo "Metainfo: OK"
+
+      # -----------------------------------------------------------------------
+      # 10. Download appimagetool and build the AppImage
+      # -----------------------------------------------------------------------
+      - name: Download appimagetool
+        run: |
+          wget -q -O appimagetool \
+            "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+          chmod +x appimagetool
+
+      - name: Build AppImage
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          ARCH=x86_64 ./appimagetool \
+            skippy-xd.AppDir \
+            "Skippy-xd-${VERSION}-x86_64.AppImage"
+          echo "Built: Skippy-xd-${VERSION}-x86_64.AppImage"
+          ls -lh Skippy-xd-*.AppImage
+
+      # -----------------------------------------------------------------------
+      # 11. Upload AppImage to the GitHub Release
+      #     softprops/action-gh-release handles both tag-triggered and
+      #     manual (workflow_dispatch) runs cleanly
+      # -----------------------------------------------------------------------
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Skippy-XD ${{ steps.version.outputs.VERSION }}"
+          body: |
+            ## Skippy-XD ${{ steps.version.outputs.VERSION }}
+
+            ### AppImage (Linux x86_64)
+            Download `Skippy-xd-${{ steps.version.outputs.VERSION }}-x86_64.AppImage`, make it executable and run:
+            ```bash
+            chmod +x Skippy-xd-${{ steps.version.outputs.VERSION }}-x86_64.AppImage
+            ./Skippy-xd-${{ steps.version.outputs.VERSION }}-x86_64.AppImage --start-daemon
+            ```
+          files: Skippy-xd-${{ steps.version.outputs.VERSION }}-x86_64.AppImage
+          fail_on_unmatched_files: true

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -48,6 +48,7 @@ jobs:
       # -----------------------------------------------------------------------
       # 3. Install build dependencies
       #    Targeting Ubuntu 22.04 Jammy baseline for maximum compatibility
+      #    libfuse2t64 is the correct package name on Ubuntu 22.04+
       # -----------------------------------------------------------------------
       - name: Install dependencies
         run: |
@@ -60,7 +61,7 @@ jobs:
             libpng-dev zlib1g-dev libjpeg-dev libgif-dev \
             libfreetype6-dev \
             desktop-file-utils appstream \
-            libfuse2
+            libfuse2t64 || sudo apt-get install -y libfuse2
 
       # -----------------------------------------------------------------------
       # 4. Build skippy-xd
@@ -93,52 +94,53 @@ jobs:
 
       # -----------------------------------------------------------------------
       # 6. AppRun
+      #    IMPORTANT: heredoc must not be indented — shebang must be at col 0
       # -----------------------------------------------------------------------
       - name: Create AppRun
         run: |
           cat > skippy-xd.AppDir/AppRun << 'APPRUN_EOF'
-          #!/bin/bash
-          HERE="$(dirname "$(readlink -f "${0}")")"
-          export PATH="${HERE}/usr/bin:${PATH}"
-          export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH}"
-          export XDG_CONFIG_DIRS="${HERE}/etc/xdg:${XDG_CONFIG_DIRS}"
-          export XDG_DATA_DIRS="${HERE}/usr/share:${XDG_DATA_DIRS}"
+#!/bin/bash
+HERE="$(dirname "$(readlink -f "${0}")")"
+export PATH="${HERE}/usr/bin:${PATH}"
+export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH}"
+export XDG_CONFIG_DIRS="${HERE}/etc/xdg:${XDG_CONFIG_DIRS}"
+export XDG_DATA_DIRS="${HERE}/usr/share:${XDG_DATA_DIRS}"
 
-          if [ "$1" = "--help-man" ]; then
-            for MP in \
-              "${HERE}/usr/share/man/man1/skippy-xd.1.gz" \
-              "${HERE}/usr/share/man/man1/skippy-xd.1"; do
-              [ -f "$MP" ] || continue
-              [[ "$MP" == *.gz ]] && zcat "$MP" | man -l - || man -l "$MP"
-              exit $?
-            done
-            echo "Error: Manpage not found"; exit 1
-          fi
+if [ "$1" = "--help-man" ]; then
+  for MP in \
+    "${HERE}/usr/share/man/man1/skippy-xd.1.gz" \
+    "${HERE}/usr/share/man/man1/skippy-xd.1"; do
+    [ -f "$MP" ] || continue
+    [[ "$MP" == *.gz ]] && zcat "$MP" | man -l - || man -l "$MP"
+    exit $?
+  done
+  echo "Error: Manpage not found"; exit 1
+fi
 
-          exec "${HERE}/usr/bin/skippy-xd" "$@"
-          APPRUN_EOF
+exec "${HERE}/usr/bin/skippy-xd" "$@"
+APPRUN_EOF
           chmod +x skippy-xd.AppDir/AppRun
 
       # -----------------------------------------------------------------------
       # 7. Desktop file
       #    NoDisplay=true — skippy-xd is a daemon, not a menu app
+      #    IMPORTANT: heredoc must not be indented — keys must be at col 0
       # -----------------------------------------------------------------------
       - name: Create desktop file
         run: |
           cat > skippy-xd.AppDir/skippy-xd.desktop << 'EOF'
-          [Desktop Entry]
-          Type=Application
-          Name=Skippy-XD
-          GenericName=Window Switcher
-          Comment=Expose-style window switcher daemon for X11
-          Exec=skippy-xd --start-daemon
-          Icon=skippy-xd
-          Terminal=false
-          Categories=Utility;X-Daemon;
-          Keywords=expose;window;switcher;daemon;x11;
-          NoDisplay=true
-          EOF
-
+[Desktop Entry]
+Type=Application
+Name=Skippy-XD
+GenericName=Window Switcher
+Comment=Expose-style window switcher daemon for X11
+Exec=skippy-xd --start-daemon
+Icon=skippy-xd
+Terminal=false
+Categories=Utility;X-Daemon;
+Keywords=expose;window;switcher;daemon;x11;
+NoDisplay=true
+EOF
           cp skippy-xd.AppDir/skippy-xd.desktop \
              skippy-xd.AppDir/usr/share/applications/skippy-xd.desktop
 
@@ -151,43 +153,44 @@ jobs:
       - name: Generate icon
         run: |
           python3 - << 'PYEOF'
-          import struct, zlib
+import struct, zlib
 
-          def write_png(filename, size=256):
-              margin    = size // 8
-              thickness = max(size // 12, 3)
-              fg = (160, 160, 160)
-              bg = (30,  30,  30)
-              rows = []
-              for y in range(size):
-                  row = bytearray([0])          # filter byte: None
-                  for x in range(size):
-                      cx, cy   = size // 2, size // 2
-                      in_m     = margin <= x <= size-margin and margin <= y <= size-margin
-                      on_diag  = in_m and (abs(x-y) < thickness or abs(x-(size-1-y)) < thickness)
-                      dist     = ((x-cx)**2 + (y-cy)**2) ** 0.5
-                      on_ring  = abs(dist - (size//2 - margin//2)) < thickness
-                      row     += bytes(fg if (on_diag or on_ring) else bg)
-                  rows.append(bytes(row))
+def write_png(filename, size=256):
+    margin    = size // 8
+    thickness = max(size // 12, 3)
+    fg = (160, 160, 160)
+    bg = (30,  30,  30)
+    rows = []
+    for y in range(size):
+        row = bytearray([0])
+        for x in range(size):
+            cx, cy  = size // 2, size // 2
+            in_m    = margin <= x <= size-margin and margin <= y <= size-margin
+            on_diag = in_m and (abs(x-y) < thickness or abs(x-(size-1-y)) < thickness)
+            dist    = ((x-cx)**2 + (y-cy)**2) ** 0.5
+            on_ring = abs(dist - (size//2 - margin//2)) < thickness
+            row    += bytes(fg if (on_diag or on_ring) else bg)
+        rows.append(bytes(row))
 
-              def chunk(tag, data):
-                  crc = zlib.crc32(tag + data) & 0xffffffff
-                  return struct.pack('>I', len(data)) + tag + data + struct.pack('>I', crc)
+    def chunk(tag, data):
+        crc = zlib.crc32(tag + data) & 0xffffffff
+        return struct.pack('>I', len(data)) + tag + data + struct.pack('>I', crc)
 
-              with open(filename, 'wb') as f:
-                  f.write(b'\x89PNG\r\n\x1a\n')
-                  f.write(chunk(b'IHDR', struct.pack('>II', size, size) + bytes([8,2,0,0,0])))
-                  f.write(chunk(b'IDAT', zlib.compress(b''.join(rows), 9)))
-                  f.write(chunk(b'IEND', b''))
+    with open(filename, 'wb') as f:
+        f.write(b'\x89PNG\r\n\x1a\n')
+        f.write(chunk(b'IHDR', struct.pack('>II', size, size) + bytes([8,2,0,0,0])))
+        f.write(chunk(b'IDAT', zlib.compress(b''.join(rows), 9)))
+        f.write(chunk(b'IEND', b''))
 
-          write_png('skippy-xd.AppDir/skippy-xd.png')
-          write_png('skippy-xd.AppDir/usr/share/icons/hicolor/256x256/apps/skippy-xd.png')
-          print("Icon: OK")
-          PYEOF
+write_png('skippy-xd.AppDir/skippy-xd.png')
+write_png('skippy-xd.AppDir/usr/share/icons/hicolor/256x256/apps/skippy-xd.png')
+print("Icon: OK")
+PYEOF
 
       # -----------------------------------------------------------------------
       # 9. AppStream metainfo
       #    Filename MUST match component <id> exactly — appstreamcli requirement
+      #    IMPORTANT: heredoc must not be indented — XML must be at col 0
       # -----------------------------------------------------------------------
       - name: Create AppStream metainfo
         run: |
@@ -195,42 +198,42 @@ jobs:
           DATE="$(date +%Y-%m-%d)"
 
           cat > "skippy-xd.AppDir/usr/share/metainfo/io.github.felixfung.skippy-xd.appdata.xml" << EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <component type="console-application">
-            <id>io.github.felixfung.skippy-xd</id>
-            <name>Skippy-XD</name>
-            <summary>Exposé-style window switcher daemon for X11</summary>
-            <metadata_license>FSFAP</metadata_license>
-            <project_license>GPL-2.0-or-later</project_license>
-            <description>
-              <p>
-                Skippy-XD is a full-screen Exposé-like task switcher for the X Window System.
-                It runs as a lightweight daemon and displays all open windows simultaneously,
-                allowing fast switching between them. Designed for minimal window managers
-                that do not provide their own expose functionality.
-              </p>
-              <p>
-                As a daemon, skippy-xd has no persistent graphical interface —
-                it activates on demand via a configurable hotkey or command.
-              </p>
-            </description>
-            <url type="homepage">https://github.com/felixfung/skippy-xd</url>
-            <url type="bugtracker">https://github.com/felixfung/skippy-xd/issues</url>
-            <developer id="io.github.felixfung">
-              <name>felixfung</name>
-            </developer>
-            <releases>
-              <release version="${VERSION}" date="${DATE}"/>
-            </releases>
-            <provides>
-              <binary>skippy-xd</binary>
-            </provides>
-            <categories>
-              <category>Utility</category>
-            </categories>
-            <content_rating type="oars-1.1"/>
-          </component>
-          EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>io.github.felixfung.skippy-xd</id>
+  <name>Skippy-XD</name>
+  <summary>Exposé-style window switcher daemon for X11</summary>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+  <description>
+    <p>
+      Skippy-XD is a full-screen Exposé-like task switcher for the X Window System.
+      It runs as a lightweight daemon and displays all open windows simultaneously,
+      allowing fast switching between them. Designed for minimal window managers
+      that do not provide their own expose functionality.
+    </p>
+    <p>
+      As a daemon, skippy-xd has no persistent graphical interface —
+      it activates on demand via a configurable hotkey or command.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/felixfung/skippy-xd</url>
+  <url type="bugtracker">https://github.com/felixfung/skippy-xd/issues</url>
+  <developer id="io.github.felixfung">
+    <name>felixfung</name>
+  </developer>
+  <releases>
+    <release version="${VERSION}" date="${DATE}"/>
+  </releases>
+  <provides>
+    <binary>skippy-xd</binary>
+  </provides>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+</component>
+EOF
 
           appstreamcli validate --no-net \
             "skippy-xd.AppDir/usr/share/metainfo/io.github.felixfung.skippy-xd.appdata.xml" \
@@ -256,8 +259,6 @@ jobs:
 
       # -----------------------------------------------------------------------
       # 11. Upload AppImage to the GitHub Release
-      #     softprops/action-gh-release handles both tag-triggered and
-      #     manual (workflow_dispatch) runs cleanly
       # -----------------------------------------------------------------------
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/deb-package.yml
+++ b/.github/workflows/deb-package.yml
@@ -23,13 +23,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: amd64
-            deb_arch: amd64
+          - deb_arch: amd64
             cc_flags: ""
             pkg_config_path: "/usr/lib/x86_64-linux-gnu/pkgconfig"
 
-          - arch: i386
-            deb_arch: i386
+          - deb_arch: i386
             cc_flags: "-m32"
             pkg_config_path: "/usr/lib/i386-linux-gnu/pkgconfig"
 
@@ -108,6 +106,8 @@ jobs:
 
       # -----------------------------------------------------------------------
       # 5. Assemble .deb package structure
+      #    Uses Felix's existing Packaging/Debian/control as the base —
+      #    only Version and Architecture are patched in
       # -----------------------------------------------------------------------
       - name: Assemble .deb (${{ matrix.deb_arch }})
         run: |
@@ -123,7 +123,7 @@ jobs:
             "$PKG_DIR/etc/xdg" \
             "$PKG_DIR/DEBIAN"
 
-          # Use make install to copy files into package dir — matches install paths exactly
+          # Install binary, man page and rc via make install
           make PREFIX=/usr DESTDIR="$(pwd)/$PKG_DIR" install
 
           # Permissions
@@ -132,22 +132,13 @@ jobs:
           # Copy README if present
           cp README* "$PKG_DIR/usr/share/doc/$PKG_NAME/" 2>/dev/null || true
 
-          # DEBIAN/control
-          cat > "$PKG_DIR/DEBIAN/control" << EOF
-          Package: $PKG_NAME
-          Version: $VERSION
-          Architecture: $DEB_ARCH
-          Maintainer: felixfung <https://github.com/felixfung>
-          Depends: libc6, libx11-6, libxft2, libxrender1, libxcomposite1, libxdamage1, libxfixes3, libxext6, libxinerama1, libpng16-16, zlib1g, libjpeg62, libgif7
-          Section: x11
-          Priority: optional
-          Homepage: https://github.com/felixfung/skippy-xd
-          Description: Full-screen Exposé-like task switcher for X11
-           Skippy-XD is a lightweight daemon that displays all open windows
-           simultaneously, allowing fast switching between them. Designed for
-           use with minimal window managers that do not provide their own
-           expose functionality.
-          EOF
+          # Use Felix's existing control file as base — patch Version and Architecture
+          cp Packaging/Debian/control "$PKG_DIR/DEBIAN/control"
+          sed -i "s/^Version:.*/Version: $VERSION/"           "$PKG_DIR/DEBIAN/control"
+          sed -i "s/^Architecture:.*/Architecture: $DEB_ARCH/" "$PKG_DIR/DEBIAN/control"
+
+          echo "--- DEBIAN/control ---"
+          cat "$PKG_DIR/DEBIAN/control"
 
           # Build the .deb
           dpkg-deb --build "$PKG_DIR" "${PKG_NAME}_${VERSION}_${DEB_ARCH}.deb"

--- a/.github/workflows/deb-package.yml
+++ b/.github/workflows/deb-package.yml
@@ -1,0 +1,177 @@
+# -----------------------------------------------------------------------------
+# Skippy-XD Debian Package Builder — GitHub Actions Workflow
+# Triggers: on every tagged release (v*) and manual dispatch
+# Produces:  skippy-xd_<version>_amd64.deb
+#            skippy-xd_<version>_i386.deb
+# Both attached to the GitHub Release page
+# -----------------------------------------------------------------------------
+
+name: Build Debian Packages
+
+on:
+  push:
+    tags:
+      - 'v*'                        # fires on v0.10.6, v1.0.0, etc.
+  workflow_dispatch:                # allows manual trigger from Actions tab
+
+permissions:
+  contents: write                   # needed to upload to GitHub Releases
+
+jobs:
+  build-deb:
+    runs-on: ubuntu-22.04           # stable LTS baseline
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            deb_arch: amd64
+            cc_flags: ""
+            pkg_config_path: "/usr/lib/x86_64-linux-gnu/pkgconfig"
+
+          - arch: i386
+            deb_arch: i386
+            cc_flags: "-m32"
+            pkg_config_path: "/usr/lib/i386-linux-gnu/pkgconfig"
+
+    steps:
+
+      # -----------------------------------------------------------------------
+      # 1. Checkout
+      # -----------------------------------------------------------------------
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # -----------------------------------------------------------------------
+      # 2. Read version from version.txt (pure bash — no awk/sed issues)
+      # -----------------------------------------------------------------------
+      - name: Read version
+        id: version
+        run: |
+          read -r raw < version.txt
+          raw="${raw%% *}"          # strip everything after first space
+          VERSION="${raw#v}"        # strip leading 'v'
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: could not parse version from version.txt"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      # -----------------------------------------------------------------------
+      # 3. Install dependencies
+      #    Enable i386 multiarch for 32-bit builds
+      # -----------------------------------------------------------------------
+      - name: Install dependencies
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            build-essential \
+            gcc \
+            gcc-multilib \
+            pkg-config \
+            libx11-dev              libx11-dev:i386 \
+            libxft-dev              libxft-dev:i386 \
+            libxrender-dev          libxrender-dev:i386 \
+            libxcomposite-dev       libxcomposite-dev:i386 \
+            libxdamage-dev          libxdamage-dev:i386 \
+            libxfixes-dev           libxfixes-dev:i386 \
+            libxext-dev             libxext-dev:i386 \
+            libxinerama-dev         libxinerama-dev:i386 \
+            libpng-dev              libpng-dev:i386 \
+            zlib1g-dev              zlib1g-dev:i386 \
+            libjpeg-dev             libjpeg-dev:i386 \
+            libgif-dev              libgif-dev:i386 \
+            libfreetype6-dev        libfreetype6-dev:i386
+
+      # -----------------------------------------------------------------------
+      # 4. Build skippy-xd
+      #    Pass clean VERSION so man page sed substitution never breaks
+      #    For i386: override CC with -m32 and point pkg-config to i386 libs
+      # -----------------------------------------------------------------------
+      - name: Build (${{ matrix.deb_arch }})
+        run: |
+          make clean
+          if [ "${{ matrix.deb_arch }}" = "i386" ]; then
+            make PREFIX=/usr \
+              CC="gcc ${{ matrix.cc_flags }}" \
+              CFLAGS="${{ matrix.cc_flags }} -DNDEBUG -O2 -D_FORTIFY_SOURCE=2" \
+              LDFLAGS="${{ matrix.cc_flags }} -Wl,-O1 -Wl,--as-needed" \
+              PKG_CONFIG_PATH="${{ matrix.pkg_config_path }}" \
+              VERSION_SKIPPYXD="${{ steps.version.outputs.VERSION }}"
+          else
+            make PREFIX=/usr \
+              VERSION_SKIPPYXD="${{ steps.version.outputs.VERSION }}"
+          fi
+
+      # -----------------------------------------------------------------------
+      # 5. Assemble .deb package structure
+      # -----------------------------------------------------------------------
+      - name: Assemble .deb (${{ matrix.deb_arch }})
+        run: |
+          PKG_NAME="skippy-xd"
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          DEB_ARCH="${{ matrix.deb_arch }}"
+          PKG_DIR="${PKG_NAME}_${VERSION}_${DEB_ARCH}"
+
+          mkdir -p \
+            "$PKG_DIR/usr/bin" \
+            "$PKG_DIR/usr/share/man/man1" \
+            "$PKG_DIR/usr/share/doc/$PKG_NAME" \
+            "$PKG_DIR/etc/xdg" \
+            "$PKG_DIR/DEBIAN"
+
+          # Use make install to copy files into package dir — matches install paths exactly
+          make PREFIX=/usr DESTDIR="$(pwd)/$PKG_DIR" install
+
+          # Permissions
+          chmod 755 "$PKG_DIR/usr/bin/skippy-xd"
+
+          # Copy README if present
+          cp README* "$PKG_DIR/usr/share/doc/$PKG_NAME/" 2>/dev/null || true
+
+          # DEBIAN/control
+          cat > "$PKG_DIR/DEBIAN/control" << EOF
+          Package: $PKG_NAME
+          Version: $VERSION
+          Architecture: $DEB_ARCH
+          Maintainer: felixfung <https://github.com/felixfung>
+          Depends: libc6, libx11-6, libxft2, libxrender1, libxcomposite1, libxdamage1, libxfixes3, libxext6, libxinerama1, libpng16-16, zlib1g, libjpeg62, libgif7
+          Section: x11
+          Priority: optional
+          Homepage: https://github.com/felixfung/skippy-xd
+          Description: Full-screen Exposé-like task switcher for X11
+           Skippy-XD is a lightweight daemon that displays all open windows
+           simultaneously, allowing fast switching between them. Designed for
+           use with minimal window managers that do not provide their own
+           expose functionality.
+          EOF
+
+          # Build the .deb
+          dpkg-deb --build "$PKG_DIR" "${PKG_NAME}_${VERSION}_${DEB_ARCH}.deb"
+
+          echo "Built: ${PKG_NAME}_${VERSION}_${DEB_ARCH}.deb"
+          ls -lh "${PKG_NAME}_${VERSION}_${DEB_ARCH}.deb"
+
+      # -----------------------------------------------------------------------
+      # 6. Upload .deb to GitHub Release
+      # -----------------------------------------------------------------------
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Skippy-XD ${{ steps.version.outputs.VERSION }}"
+          body: |
+            ## Skippy-XD ${{ steps.version.outputs.VERSION }}
+
+            ### Debian/Ubuntu packages
+            Download the `.deb` matching your system architecture and install with:
+            ```bash
+            sudo dpkg -i skippy-xd_${{ steps.version.outputs.VERSION }}_amd64.deb
+            # or for 32-bit systems:
+            sudo dpkg -i skippy-xd_${{ steps.version.outputs.VERSION }}_i386.deb
+            ```
+          files: skippy-xd_${{ steps.version.outputs.VERSION }}_${{ matrix.deb_arch }}.deb
+          fail_on_unmatched_files: true

--- a/.github/workflows/rpm-package.yml
+++ b/.github/workflows/rpm-package.yml
@@ -1,0 +1,240 @@
+# -----------------------------------------------------------------------------
+# Skippy-XD RPM Package Builder — GitHub Actions Workflow
+# Triggers: on every tagged release (v*) and manual dispatch
+# Produces:  skippy-xd-<version>-1.x86_64.rpm
+#            skippy-xd-<version>-1.i686.rpm
+# Both attached to the GitHub Release page
+# Uses Fedora container for authentic RPM building
+# -----------------------------------------------------------------------------
+
+name: Build RPM Packages
+
+on:
+  push:
+    tags:
+      - 'v*'                        # fires on v0.10.6, v1.0.0, etc.
+  workflow_dispatch:                # allows manual trigger from Actions tab
+
+permissions:
+  contents: write                   # needed to upload to GitHub Releases
+
+jobs:
+  build-rpm:
+    runs-on: ubuntu-22.04
+    container:
+      image: fedora:latest          # authentic RPM environment
+
+    strategy:
+      matrix:
+        include:
+          - rpm_arch: x86_64
+            cc_flags: ""
+            pkg_config_path: "/usr/lib64/pkgconfig"
+
+          - rpm_arch: i686
+            cc_flags: "-m32"
+            pkg_config_path: "/usr/lib/pkgconfig"
+
+    steps:
+
+      # -----------------------------------------------------------------------
+      # 1. Checkout
+      # -----------------------------------------------------------------------
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # -----------------------------------------------------------------------
+      # 2. Read version from version.txt (pure bash — no awk/sed issues)
+      # -----------------------------------------------------------------------
+      - name: Read version
+        id: version
+        run: |
+          read -r raw < version.txt
+          raw="${raw%% *}"          # strip everything after first space
+          VERSION="${raw#v}"        # strip leading 'v'
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: could not parse version from version.txt"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      # -----------------------------------------------------------------------
+      # 3. Install build dependencies
+      #    glibc-devel.i686 and libgcc.i686 needed for 32-bit builds
+      # -----------------------------------------------------------------------
+      - name: Install dependencies
+        run: |
+          dnf install -y \
+            gcc \
+            gcc-c++ \
+            make \
+            pkgconfig \
+            rpm-build \
+            rpmdevtools \
+            libX11-devel \
+            libXft-devel \
+            libXrender-devel \
+            libXcomposite-devel \
+            libXdamage-devel \
+            libXfixes-devel \
+            libXext-devel \
+            libXinerama-devel \
+            libpng-devel \
+            zlib-devel \
+            libjpeg-turbo-devel \
+            giflib-devel \
+            freetype-devel \
+            glibc-devel.i686 \
+            libgcc.i686 \
+            libX11-devel.i686 \
+            libXft-devel.i686 \
+            libXrender-devel.i686 \
+            libXcomposite-devel.i686 \
+            libXdamage-devel.i686 \
+            libXfixes-devel.i686 \
+            libXext-devel.i686 \
+            libXinerama-devel.i686 \
+            libpng-devel.i686 \
+            zlib-devel.i686 \
+            libjpeg-turbo-devel.i686 \
+            giflib-devel.i686 \
+            freetype-devel.i686
+
+      # -----------------------------------------------------------------------
+      # 4. Build skippy-xd
+      #    Pass clean VERSION so man page sed substitution never breaks
+      # -----------------------------------------------------------------------
+      - name: Build (${{ matrix.rpm_arch }})
+        run: |
+          make clean
+          if [ "${{ matrix.rpm_arch }}" = "i686" ]; then
+            make PREFIX=/usr \
+              CC="gcc ${{ matrix.cc_flags }}" \
+              CFLAGS="${{ matrix.cc_flags }} -DNDEBUG -O2 -D_FORTIFY_SOURCE=2" \
+              LDFLAGS="${{ matrix.cc_flags }} -Wl,-O1 -Wl,--as-needed" \
+              PKG_CONFIG_PATH="${{ matrix.pkg_config_path }}" \
+              VERSION_SKIPPYXD="${{ steps.version.outputs.VERSION }}"
+          else
+            make PREFIX=/usr \
+              VERSION_SKIPPYXD="${{ steps.version.outputs.VERSION }}"
+          fi
+
+      # -----------------------------------------------------------------------
+      # 5. Set up RPM build tree and install built files
+      # -----------------------------------------------------------------------
+      - name: Set up RPM build tree (${{ matrix.rpm_arch }})
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          RPM_ARCH="${{ matrix.rpm_arch }}"
+
+          rpmdev-setuptree
+
+          # Install into BUILDROOT
+          BUILDROOT="$HOME/rpmbuild/BUILDROOT/skippy-xd-${VERSION}-1.${RPM_ARCH}"
+          mkdir -p \
+            "$BUILDROOT/usr/bin" \
+            "$BUILDROOT/usr/share/man/man1" \
+            "$BUILDROOT/etc/xdg"
+
+          make PREFIX=/usr DESTDIR="$BUILDROOT" install
+
+          chmod 755 "$BUILDROOT/usr/bin/skippy-xd"
+
+      # -----------------------------------------------------------------------
+      # 6. Generate .spec file
+      #    Kept minimal — KISS, matches Makefile dependencies exactly
+      # -----------------------------------------------------------------------
+      - name: Create spec file (${{ matrix.rpm_arch }})
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          RPM_ARCH="${{ matrix.rpm_arch }}"
+
+          cat > "$HOME/rpmbuild/SPECS/skippy-xd.spec" << EOF
+Name:           skippy-xd
+Version:        ${VERSION}
+Release:        1%{?dist}
+Summary:        Full-screen Expose-like task switcher for X11
+License:        GPL-2.0-or-later
+URL:            https://github.com/felixfung/skippy-xd
+BuildArch:      ${RPM_ARCH}
+
+Requires:       libX11
+Requires:       libXft
+Requires:       libXrender
+Requires:       libXcomposite
+Requires:       libXdamage
+Requires:       libXfixes
+Requires:       libXext
+Requires:       libXinerama
+Requires:       libpng
+Requires:       zlib
+Requires:       libjpeg-turbo
+Requires:       giflib
+Requires:       freetype
+
+%description
+Skippy-XD is a lightweight daemon that displays all open windows
+simultaneously, allowing fast switching between them. Designed for
+use with minimal window managers that do not provide their own
+expose functionality.
+
+%install
+# Files already staged in BUILDROOT by 'make install' step above
+# Nothing to do here
+
+%files
+%{_bindir}/skippy-xd
+%{_mandir}/man1/skippy-xd.1*
+%config(noreplace) %{_sysconfdir}/xdg/skippy-xd.rc
+
+%changelog
+* $(date "+%a %b %d %Y") felixfung <https://github.com/felixfung> - ${VERSION}-1
+- Automated release build
+EOF
+
+          echo "==> spec file:"
+          cat "$HOME/rpmbuild/SPECS/skippy-xd.spec"
+
+      # -----------------------------------------------------------------------
+      # 7. Build the RPM
+      # -----------------------------------------------------------------------
+      - name: Build RPM (${{ matrix.rpm_arch }})
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          RPM_ARCH="${{ matrix.rpm_arch }}"
+
+          rpmbuild -bb \
+            --target "${RPM_ARCH}" \
+            --define "_rpmdir $(pwd)" \
+            "$HOME/rpmbuild/SPECS/skippy-xd.spec"
+
+          # Find and rename to flat output
+          find . -name "skippy-xd-*.rpm" -not -path "*/SRPMS/*" \
+            -exec cp {} "skippy-xd-${VERSION}-1.${RPM_ARCH}.rpm" \;
+
+          echo "Built: skippy-xd-${VERSION}-1.${RPM_ARCH}.rpm"
+          ls -lh "skippy-xd-${VERSION}-1.${RPM_ARCH}.rpm"
+
+      # -----------------------------------------------------------------------
+      # 8. Upload RPM to GitHub Release
+      # -----------------------------------------------------------------------
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Skippy-XD ${{ steps.version.outputs.VERSION }}"
+          body: |
+            ## Skippy-XD ${{ steps.version.outputs.VERSION }}
+
+            ### RPM packages (Fedora/openSUSE/RHEL)
+            Download the `.rpm` matching your system architecture and install with:
+            ```bash
+            sudo rpm -i skippy-xd-${{ steps.version.outputs.VERSION }}-1.x86_64.rpm
+            # or for 32-bit systems:
+            sudo rpm -i skippy-xd-${{ steps.version.outputs.VERSION }}-1.i686.rpm
+            ```
+          files: skippy-xd-${{ steps.version.outputs.VERSION }}-1.${{ matrix.rpm_arch }}.rpm
+          fail_on_unmatched_files: true


### PR DESCRIPTION
Hey Felix,

I've been playing around with packaging skippy-xd as an AppImage and got it working nicely. I put together a small GitHub Actions workflow that builds it automatically on every tagged release and attaches the AppImage as a ready-to-download file on the GitHub Release page — no changes to your source or Makefile needed.

A few things I sorted out along the way:
- Reads version cleanly from version.txt so the man page builds correctly
- Targets Ubuntu 22.04 for maximum compatibility
- Includes valid AppStream metainfo and desktop file
- Added --help-man flag to the AppImage so users can still access the man page (AppImages can't use the system man directly)

Users can then just download and run it directly from the release page without needing to compile from source.

If you want skippy-xd listed on AppImageHub for even broader discoverability, submitting it is minimal effort — just a PR to appimage.github.io adding a single file called database/skippy-xd containing one line:
https://github.com/felixfung/skippy-xd

I know you're busy — no hurry at all.