### PR TITLE
Regex expressions for window filtering

### DIFF
--- a/skippy-xd.1.in
+++ b/skippy-xd.1.in
@@ -90,18 +90,17 @@ and returns all selected window/desktop IDs, enabling sophisticated scripting.
 .SS
 .B --wm-class
 .I CLASS
-Display only windows belonging to the specified WM
-class.
+Display only windows belonging to the specified WM class. Use ',', '!' for OR, NOT logic. Use '*' for wildcard.
 .TP
 .SS
 .B --wm-title
 .I TITLE
-Display only windows matching the specified title.
+Display only windows matching the specified title. Use ',', '!' for OR, NOT logic. Use '*' for wildcard.
 .TP
 .SS
 .B --wm-status
 .I STATUS
-Display only windows with the specified status.
+Display only windows with the specified status. Use ',', '!' for OR, NOT logic.
 Valid status values are:
 .RS
 .IP "sticky" 4
@@ -124,7 +123,7 @@ Fully maximized windows
 .B --desktop
 .I DESKTOP
 Display only windows on the specified virtual
-desktop. Use
+desktop. Use ',', '!' for OR, NOT logic. Use
 .B -1
 to show windows from all desktops.
 .TP
@@ -218,10 +217,10 @@ skippy-xd --expose --pivot Super_L --next
 Activate expose via pivot mode with Super_L
 as the pivot key, highlighting the next window.
 .PP
-skippy-xd --expose --desktop -1 --wm-class firefox --wm-status float,maximized_vert --config ~/.config/skippy-xd/other.rc
+skippy-xd --expose --desktop -1 --wm-class firefox --wm-title '!firefox' --wm-status float,maximized_vert --config ~/.config/skippy-xd/other.rc
 .IP
 Show Firefox windows from all desktops that are
-floating or vertically maximized, with custom config file.
+floating or vertically maximized, with custom config file, excluding those whose window title contains 'firefox'.
 .SH COMPATIBILITY
 .B skippy-xd
 works with any X Window Manager and desktop

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -81,25 +81,53 @@ clientwin_filter_func(dlist *l, void *data) {
 	}
 	else {
 		bool filter_matched = false;
-		if (w_desktop == -1)
-			filtered_in = true; // always show sticky windows
+		bool matched_any_rule = false;
+		bool has_positive_rule = false;
 
+		// Sticky windows always shown
+		if (w_desktop == (CARD32) -1)
+			return wm_validate_window(mw->ps, cw->wid_client);
+
+		const char *str = ps->o.desktops;
+		int len = strlen(str);
 		int anchor = 0;
-		for (int i=0; i<strlen(ps->o.desktops) + 1 && !filter_matched; i++)
-			if (ps->o.desktops[i] == ',' || ps->o.desktops[i] == '\0') {
-				char *buffer = malloc(i - anchor);
-				memcpy(buffer, ps->o.desktops+anchor, i - anchor);
+
+		for (int i = 0; i <= len; i++) {
+			if (str[i] == ',' || str[i] == '\0') {
+				int token_len = i - anchor;
+				bool negate = false;
+				int start = anchor;
+
+				if (str[start] == '!') {
+					negate = true;
+					start++;
+					token_len--;
+				}
+				else
+					has_positive_rule = true;
+
+				char buffer[32];
+				if (token_len >= (int)sizeof(buffer))
+					token_len = sizeof(buffer) - 1;
+
+				memcpy(buffer, str + start, token_len);
+				buffer[token_len] = '\0';
+
 				int desktop = atoi(buffer);
 
-				if (desktop == -1)
-					filter_matched = true;
-				else
-					filter_matched = w_desktop == desktop;
+				bool rule_matches =
+					(desktop == -1) ||
+					(w_desktop == (CARD32)desktop);
 
+				if (rule_matches) {
+					matched_any_rule = true;
+					filter_matched = !negate;
+				}
 				anchor = i + 1;
-				free(buffer);
 			}
-		filtered_in = filter_matched;
+		}
+
+		filtered_in = matched_any_rule? filter_matched: !has_positive_rule;
 	}
 
 	if (filtered_in)

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -2545,7 +2545,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 					if (optarg[i] != '-' && optarg[i] != ',' && optarg[i] != '!'
 							&& !('0'<=optarg[i] && optarg[i]<='9')) {
 						printfef(true,
-							"(): --desktop argument accepts only numerals and comma");
+							"(): --desktop argument accepts only numerals, comma, or exclaimation");
 						exit(1);
 					}
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -2489,12 +2489,11 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 					ps->o.wm_class = mstrdup(optarg);
 				else {
 					char* newclass = malloc(
-							(strlen(ps->o.wm_class) + strlen(optarg) + 3)*sizeof(char));
-					newclass[0] = '('; newclass[1] = '\0';
+							(strlen(ps->o.wm_class) + strlen(optarg) + 2)*sizeof(char));
+					newclass[0] = '\0';
 					strcat(newclass, ps->o.wm_class);
 					strcat(newclass, ",");
 					strcat(newclass, optarg);
-					strcat(newclass, ")");
 					free(ps->o.wm_class);
 					ps->o.wm_class = newclass;
 				}
@@ -2505,12 +2504,11 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 					ps->o.wm_title = mstrdup(optarg);
 				else {
 					char* newtitle = malloc(
-							(strlen(ps->o.wm_title) + strlen(optarg) + 3)*sizeof(char));
-					newtitle[0] = '('; newtitle[1] = '\0';
+							(strlen(ps->o.wm_title) + strlen(optarg) + 2)*sizeof(char));
+					newtitle[0] = '\0';
 					strcat(newtitle, ps->o.wm_title);
 					strcat(newtitle, ",");
 					strcat(newtitle, optarg);
-					strcat(newtitle, ")");
 					free(ps->o.wm_title);
 					ps->o.wm_title = newtitle;
 				}

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -2567,7 +2567,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 				break;
 			case OPT_DESKTOP:
 				for (int i=0; i<strlen(optarg); i++)
-					if (optarg[i] != '-' && optarg[i] != ','
+					if (optarg[i] != '-' && optarg[i] != ',' && optarg[i] != '!'
 							&& !('0'<=optarg[i] && optarg[i]<='9')) {
 						printfef(true,
 							"(): --desktop argument accepts only numerals and comma");

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -710,7 +710,7 @@ activate_via_fifo(session_t *ps, const char *pipePath) {
 	char command[BUF_LEN*2];
 	char nparams = ps->o.multiselect
 		+ (ps->o.wm_class != NULL) + (ps->o.wm_title != NULL)
-		+ (ps->o.wm_status_count > 0)
+		+ (ps->o.wm_status != NULL)
 		+ (ps->o.desktops != NULL)
 		+ (ps->o.pivotkey != 0);
 	if (ps->o.config_reload_path || ps->o.config_reload)
@@ -766,10 +766,10 @@ activate_via_fifo(session_t *ps, const char *pipePath) {
 	}
 
 	if (ps->o.wm_status) {
-		cmd_len += 1+1+ps->o.wm_status_count+1;
-		char status[1+1+ps->o.wm_status_count+1];
+		cmd_len += 1+1+strlen(ps->o.wm_status)+1;
+		char status[1+1+strlen(ps->o.wm_status)+1];
 		sprintf(status, "%c%c%s",
-				PIPEPRM_WM_STATUS, (char)ps->o.wm_status_count, ps->o.wm_status_str);
+				PIPEPRM_WM_STATUS, (char)strlen(ps->o.wm_status), ps->o.wm_status);
 		strcat(command, status);
 	}
 
@@ -2004,11 +2004,8 @@ mainloop(session_t *ps, bool activate_on_start) {
 							ps->o.wm_title = NULL;
 						}
 						if (ps->o.wm_status) {
-							ps->o.wm_status_count = 0;
 							free(ps->o.wm_status);
 							ps->o.wm_status = NULL;
-							free(ps->o.wm_status_str);
-							ps->o.wm_status_str = NULL;
 						}
 						if (ps->o.desktops) {
 							free(ps->o.desktops);
@@ -2047,15 +2044,9 @@ mainloop(session_t *ps, bool activate_on_start) {
 							}
 
 							if (param[i] & PIPEPRM_WM_STATUS) {
-								if (ps->o.wm_status) {
+								if (ps->o.wm_status)
 									free(ps->o.wm_status);
-									free(ps->o.wm_status_str);
-								}
-								ps->o.wm_status_str = mstrdup(str[i]);
-								ps->o.wm_status_count = strlen(ps->o.wm_status_str);
-								ps->o.wm_status = malloc(ps->o.wm_status_count * sizeof(int));
-								for (int j=0; j<ps->o.wm_status_count; j++)
-									ps->o.wm_status[j] = ps->o.wm_status_str[j];
+								ps->o.wm_status = mstrdup(str[i]);
 							}
 
 							if (param[i] & PIPEPRM_DESKTOPS) {
@@ -2530,40 +2521,26 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 				int anchor = 0;
 				for (int i=0; i<strlen(optarg) + 1; i++)
 					if (optarg[i] == ',' || optarg[i] == '\0') {
+						if (optarg[anchor] == '!')
+							anchor++;
 						char *status = malloc(i - anchor);
 						for (int j=anchor; j<i; j++)
 							status[j-anchor] = optarg[j];
 						status[i-anchor] = '\0';
 						anchor = i + 1;
 
-						int wm_status = wm_get_status(status);
-						if (wm_status == 0) {
+						int temp = wm_get_status(status);
+						if (temp == 0) {
 							printfef(true,
 								"(): window status %s not recognized",
 								status);
 							exit(1);
 						}
 						free(status);
-
-						int count = ps->o.wm_status_count;
-
-						int *newptr = malloc(count+1);
-						for (int j=0; j<count; j++)
-							newptr[j] = ps->o.wm_status[j];
-						newptr[count] = wm_status;
-
-						ps->o.wm_status_count++;
-						free(ps->o.wm_status);
-
-						ps->o.wm_status = newptr;
 					}
 
-				ps->o.wm_status_str = malloc(ps->o.wm_status_count+1);
-				for (int i=0; i<ps->o.wm_status_count; i++)
-					ps->o.wm_status_str[i] = ps->o.wm_status[i];
-				ps->o.wm_status_str[ps->o.wm_status_count] = '\0';
+				ps->o.wm_status = strdup(optarg);
 			}
-
 				break;
 			case OPT_DESKTOP:
 				for (int i=0; i<strlen(optarg); i++)
@@ -3146,10 +3123,8 @@ main_end:
 			free(ps->o.wm_class);
 		if (ps->o.wm_title)
 			free(ps->o.wm_title);
-		if (ps->o.wm_status_count > 0)
+		if (ps->o.wm_status)
 			free(ps->o.wm_status);
-		if (ps->o.wm_status_count > 0)
-			free(ps->o.wm_status_str);
 		if (ps->o.desktops)
 			free(ps->o.desktops);
 

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -207,9 +207,7 @@ typedef struct {
 	bool filterxscreen;
 	char *wm_class;
 	char *wm_title;
-	int wm_status_count;
-	int *wm_status;
-	char *wm_status_str;
+	char *wm_status;
 	char *desktops;
 
 	int switchLayout;
@@ -300,9 +298,7 @@ typedef struct {
 \
 	.showOnlyCurrentMonitor = false, \
 	.filterxscreen = true, \
-	.wm_status_count = 0, \
 	.wm_status = NULL, \
-	.wm_status_str = "", \
 \
 	.switchLayout = LAYOUT_XD, \
 	.exposeLayout = LAYOUT_COSMOS, \

--- a/src/wm.c
+++ b/src/wm.c
@@ -789,64 +789,109 @@ wm_validate_window(session_t *ps, Window wid) {
 			return false;
 	}
 
-	if (ps->o.wm_status_count > 0) {
-		bool statusfilter = false;
+	if (ps->o.wm_status) {
+		bool positive_match = false;
+		bool negative_match = false;
+		bool have_positive = false;
+		bool have_negative = false;
+
 		bool maxvert = false;
 		bool maxhorz = false;
-		bool filtering4float = false, floating = true;
-		bool filtering4max = false;
-		if (WMPSN_EWMH == ps->wmpsn) {
-			winprop_t prop = wid_get_prop(ps, wid, _NET_WM_STATE, 8192, XA_ATOM, 32);
-			for (int i = 0; i < prop.nitems; i++) {
-				long v = prop.data32[i];
-				maxvert |= v == _NET_WM_STATE_MAXIMIZED_VERT;
-				maxhorz |= v == _NET_WM_STATE_MAXIMIZED_HORZ;
+		bool floating = false;
 
-				for (int j=0; j<ps->o.wm_status_count && !statusfilter; j++) {
-					if (status2atom(ps->o.wm_status[j]) ==
-							(_NET_WM_STATE_MAXIMIZED_VERT + _NET_WM_STATE_MAXIMIZED_HORZ)) {
-						filtering4max = true;
-					}
-					else {
-						statusfilter = v == status2atom(ps->o.wm_status[j]);
-					}
-				}
-			}
-			if (prop.nitems == 0) {
+		winprop_t ewmh_prop = {0};
+		unsigned long gnome_state = 0;
+		bool use_ewmh = WMPSN_EWMH == ps->wmpsn;
+
+		if (use_ewmh) {
+			ewmh_prop = wid_get_prop(ps, wid, _NET_WM_STATE, 8192, XA_ATOM, 32);
+			if (ewmh_prop.nitems == 0)
 				floating = true;
-				for (int j=0; j<ps->o.wm_status_count && !statusfilter; j++) {
-					if (ps->o.wm_status[j] == -1)
-						filtering4float = true;
-				}
+
+			for (int i = 0; i < ewmh_prop.nitems; i++) {
+				Atom a = (Atom)ewmh_prop.data32[i];
+				if (a == _NET_WM_STATE_MAXIMIZED_VERT)
+					maxvert = true;
+				if (a == _NET_WM_STATE_MAXIMIZED_HORZ)
+					maxhorz = true;
 			}
-			free_winprop(&prop);
-		}
-		else if (WMPSN_GNOME == ps->wmpsn) {
+		} else if (WMPSN_GNOME == ps->wmpsn) {
 			winprop_t prop = wid_get_prop(ps, wid, _WIN_STATE, 1, XA_CARDINAL, 0);
-			maxvert |= (winprop_get_int(&prop) & _NET_WM_STATE_MAXIMIZED_VERT);
-			maxhorz |= (winprop_get_int(&prop) & _NET_WM_STATE_MAXIMIZED_HORZ);
+			gnome_state = winprop_get_int(&prop);
 
-			for (int i=0; i<ps->o.wm_status_count && !statusfilter; i++) {
-				if (status2atom(ps->o.wm_status[i]) ==
-						(WIN_STATE_MAXIMIZED_VERT | WIN_STATE_MAXIMIZED_HORIZ)) {
-					filtering4max = true;
-				}
-				else if (ps->o.wm_status[i] == -1) {
-					filtering4float = true;
-				}
-				else {
-					statusfilter = (winprop_get_int(&prop) & ps->o.wm_status[i])
-							== ps->o.wm_status[i];
-					floating = false;
-				}
-			}
+			if (gnome_state == 0)
+				floating = true;
+
+			if (gnome_state & WIN_STATE_MAXIMIZED_VERT)
+				maxvert = true;
+			if (gnome_state & WIN_STATE_MAXIMIZED_HORIZ)
+				maxhorz = true;
+
 			free_winprop(&prop);
 		}
 
-		if (filtering4max)
-			statusfilter |= maxvert && maxhorz;
-		if (filtering4float)
-			statusfilter |= floating;
+		char *input = strdup(ps->o.wm_status);
+		char *saveptr = NULL;
+		char *token = strtok_r(input, ",", &saveptr);
+
+		while (token) {
+			while (*token == ' ')
+				token++;
+
+			bool negated = false;
+			if (*token == '!') {
+				negated = true;
+				token++;
+				have_negative = true;
+			} else
+				have_positive = true;
+
+			int status = wm_get_status(token);
+			bool match = false;
+
+			if (status == -1)
+				match = floating;
+			else if (status == (WIN_STATE_MAXIMIZED_VERT | WIN_STATE_MAXIMIZED_HORIZ))
+				match = maxvert && maxhorz;
+			else if (status == WIN_STATE_MAXIMIZED_VERT)
+				match = maxvert;
+			else if (status == WIN_STATE_MAXIMIZED_HORIZ)
+				match = maxhorz;
+			else if (status != 0) {
+				if (use_ewmh) {
+					Atom atom = status2atom(status);
+					for (int i = 0; i < ewmh_prop.nitems; i++)
+						if ((Atom)ewmh_prop.data32[i] == atom) {
+							match = true;
+							break;
+						}
+				} else
+					match = (gnome_state & status) == status;
+			}
+
+			if (negated) {
+				if (match)
+					negative_match = true;
+			} else {
+				if (match)
+					positive_match = true;
+			}
+
+			token = strtok_r(NULL, ",", &saveptr);
+		}
+
+		free(input);
+
+		if (use_ewmh)
+			free_winprop(&ewmh_prop);
+
+		bool statusfilter = false;
+
+		if (have_positive)
+			statusfilter = positive_match && !negative_match;
+		else if (have_negative)
+			statusfilter = !negative_match;
+
 		if (!statusfilter)
 			return false;
 	}

--- a/src/wm.c
+++ b/src/wm.c
@@ -901,7 +901,7 @@ wm_validate_window(session_t *ps, Window wid) {
 		if (hints){
 			XGetClassHint(ps->dpy, wid, hints);
 			bool regmatch_class = match_expr(ps->o.wm_class, hints->res_class);
-			bool regmatch_name = match_expr(ps->o.wm_class, hints->res_class);
+			bool regmatch_name = match_expr(ps->o.wm_class, hints->res_name);
 
 			if (!regmatch_class && !regmatch_name)
 				return false;

--- a/src/wm.c
+++ b/src/wm.c
@@ -169,73 +169,65 @@ wm_get_atoms(session_t *ps) {
 }
 
 static bool
-contains_ci(const char *s, const char *sub) {
-	if (!*sub) return true;
-	for (; *s; s++) {
-		const char *a = s, *b = sub;
-		while (*a && *b &&
-				tolower((unsigned char)*a) == tolower((unsigned char)*b)) {
-			a++;
-			b++;
-		}
-		if (!*b) return true;
+regexmatch(const char *pattern, const char *str)
+{
+	if (*pattern == '\0') return true;
+	if (*pattern == '*')
+		// Try matching zero characters or consume one character and stay on '*'
+		return regexmatch(pattern + 1, str) || (*str && regexmatch(pattern, str + 1));
+	else
+		return (*str && *pattern == *str) && regexmatch(pattern + 1, str + 1);
+}
+
+static bool
+regexmatch_partial(const char *pattern, const char *str)
+{
+	size_t len = strlen(str);
+	for (size_t i = 0; i <= len; i++) {
+		if (regexmatch(pattern, str + i))
+			return true;
 	}
 	return false;
 }
 
 static bool
-eval(const char *subexpr, const char *text, const char **next) {
-	const char *p = subexpr;
-	bool result = true;
+match_expr(const char *expr_list, const char *str)
+{
+	bool has_positive = false;
+	bool positive_match = false;
 
-	while (*p && *p != ')') {
-		bool negate = false;
-		bool value;
-
-		while (*p && isspace((unsigned char)*p)) p++;
-
-		if (*p == '!') {
-			negate = true;
-			p++;
+	char *copy = strdup(expr_list);
+	char *token = strtok(copy, ",");
+    
+	while (token) {
+		while (*token == ' ') token++;
+		char *end = token + strlen(token) - 1;
+		while (end > token && (*end == ' ' || *end == '\n')) {
+			*end = '\0';
+			end--;
 		}
 
-		if (*p == '(') {
-			p++;
-			value = eval(p, text, &p);
-		}
-		else {
-			char buf[256];
-			size_t i = 0;
-			while (*p && !isspace((unsigned char)*p)
-					&& *p != ',' && *p != ')' && i < sizeof(buf)-1)
-				buf[i++] = *p++;
-			buf[i] = '\0';
-			value = (i>0) && contains_ci(text, buf);
-		}
-
-		if (negate) value = !value;
-		result &= value;
-
-		while (*p && isspace((unsigned char)*p)) p++;
-
-		if (*p == ',') {
-			bool or_result = result;
-			while (*p == ',') {
-				p++;
-				or_result |= eval(p, text, &p);
+		if (*token == '!') {
+			if (regexmatch_partial(token + 1, str)) {
+				free(copy);
+				return false; // negative overrides everything
 			}
-			if (next) *next = p;
-			return or_result;
+		} else {
+			has_positive = true;
+			if (regexmatch_partial(token, str))
+				positive_match = true;
 		}
+
+		token = strtok(NULL, ",");
 	}
 
-	if (next) *next = p;
-	return result;
-}
+	free(copy);
 
-static bool
-match_expr(const char *expr, const char *text) {
-	return eval(expr, text, NULL);
+	// If there are positive expressions,
+	// 	   return whether any matched
+	// If there are no positive expressions,
+	//     return true (everything allowed) unless a negative blocked it
+	return has_positive? positive_match: true;
 }
 
 int wm_get_status(char *status) {


### PR DESCRIPTION
Previous regex design/implementation for window filtering has been subpar:

Window class/title filtering regex design was unnecessarily sophisticated, and there was implementation bug.

No regex for window status/desktop filtering.

I presumed previously POSIX regex allows something as simple as negation and/or wildcard, but that was not the case.

Now:

Window status and desktop filtering accepts '!' to do negation:
- `skippy-xd --expose --desktop '!2'` shows all desktops other than desktop 2
- `skippy-xd --expose --wm-status '!minimized` shows all status other than minimized windows
- Combo between positive and negative window filtering

Window class/title filtering accepts '!' to do negation, and '*' to do wildcard:
- '*' matches 0 or more characters of any character
- ',' to join different regex expressions
- '!' to show anything EXCEPT these expressions
- in case all expressions are negative, show all class/title EXCEPT the negative expressions
- in case there are positive expressions and negative expressions, show all positively matched class/title EXCEPT the negatively matched expressions

I hope the designed behaviour is more intuitive than the explanation.

Please test extensively. Thanks!