### PR TITLE
Fixed and tested all three packaging workflows (deb, rpm, appimage):

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -18,9 +18,9 @@ jobs:
         id: version
         run: |
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            VERSION=$(echo "${GITHUB_REF#refs/tags/v}" | grep -oP '^\d+\.\d+\.\d+')
+            VERSION="${GITHUB_REF#refs/tags/v}"
           else
-            VERSION=$(grep -oP '\d+\.\d+\.\d+' version.txt | head -1)
+            VERSION=$(sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/' version.txt | head -1)
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Detected version: $VERSION"

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -24,7 +24,7 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
-            VERSION=$(grep -oP '\d+\.\d+\.\d+' version.txt | head -1)
+            VERSION=$(sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/' version.txt | head -1)
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Detected version: $VERSION"

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -18,9 +18,11 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          # Strip tag prefix and any suffix like -rpm3, keeping only x.y.z
-          RAW="${GITHUB_REF#refs/tags/v}"
-          VERSION=$(echo "$RAW" | grep -oP '^\d+\.\d+\.\d+')
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION=$(sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/' version.txt | head -1)
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Detected version: $VERSION"
 

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -42,9 +42,11 @@ jobs:
       - name: Create source tarball
         run: |
           VERSION=${{ steps.version.outputs.version }}
+          # Strip suffix for tarball name (must match spec file Source0)
+          RPM_VERSION=$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           mkdir -p /tmp/skippy-xd-$VERSION
           cp -r . /tmp/skippy-xd-$VERSION/
-          tar -czf ~/rpmbuild/SOURCES/skippy-xd-$VERSION.tar.gz \
+          tar -czf ~/rpmbuild/SOURCES/skippy-xd-$RPM_VERSION.tar.gz \
             -C /tmp skippy-xd-$VERSION/
 
       - name: Prepare spec file

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -50,9 +50,11 @@ jobs:
       - name: Prepare spec file
         run: |
           VERSION=${{ steps.version.outputs.version }}
+          # Strip any suffix like -test, -rc1, etc. (RPM doesn't allow hyphens in Version)
+          RPM_VERSION=$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           DATE=$(date '+%a %b %d %Y')
           sed \
-            -e "s/VERSION_PLACEHOLDER/$VERSION/g" \
+            -e "s/VERSION_PLACEHOLDER/$RPM_VERSION/g" \
             -e "s/\$(date '+%a %b %d %Y')/$DATE/g" \
             Packaging/RPM/skippy-xd.spec > ~/rpmbuild/SPECS/skippy-xd.spec
 

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -42,12 +42,11 @@ jobs:
       - name: Create source tarball
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          # Strip suffix for tarball name (must match spec file Source0)
           RPM_VERSION=$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-          mkdir -p /tmp/skippy-xd-$VERSION
-          cp -r . /tmp/skippy-xd-$VERSION/
+          mkdir -p /tmp/skippy-xd-$RPM_VERSION
+          cp -r . /tmp/skippy-xd-$RPM_VERSION/
           tar -czf ~/rpmbuild/SOURCES/skippy-xd-$RPM_VERSION.tar.gz \
-            -C /tmp skippy-xd-$VERSION/
+            -C /tmp skippy-xd-$RPM_VERSION/
 
       - name: Prepare spec file
         run: |

--- a/skippy-xd.1
+++ b/skippy-xd.1
@@ -1,0 +1,284 @@
+.TH SKIPPY-XD 1 "skippy-xd v0.10.6 (2026.1.4) - 'Brainrot 67' Edition" "User Commands"
+.SH NAME
+skippy-xd - lightweight X11 window selector with
+switch/expose/paging.
+.SH SYNOPSIS
+.B skippy-xd
+.RI [ COMMAND  ]
+.SH DESCRIPTION
+.B skippy-xd
+is a lightweight, window-manager-agnostic window
+selector for the X server. It provides three window 
+metaphors: switch (closest to Alt-Tab),
+expose (inspired by macOS), paging
+(overview of virtual desktops). These can be
+activated via toggle or pivot activation modes.
+.PP
+The application works as a daemon that can be
+controlled via command-line interface. When run without
+arguments, it activates expose mode once without
+connecting to the daemon.
+.SS PARAMETERS
+
+.TP
+.B [NO PARAMETER]
+Activate expose mode without connecting to any daemon processes.
+.TP
+.B Daemon Management
+.TP
+.SS
+.B --start-daemon
+Start skippy-xd as daemon. The daemon collects live preview
+snapshots of windows in the background. These are used for
+unmapped windows: usually windows that are
+minimized or shaded windows, or windows on other virtual desktops.
+.TP
+.SS
+.B --stop-daemon
+Terminate the skippy-xd daemon.
+.TP
+.B Metaphors
+.TP
+.SS
+.B --switch
+Connect to the daemon and activate switch.
+Switch is closest to Alt-Tab.
+Combine with
+.B --next
+or
+.B --prev
+to focus the next/previous window.
+.TP
+.SS
+.B --expose
+Connect to the daemon and activate expose.
+In expose, inspired by MacOS, windows fly out
+and do not overlap, allowing selection by keyboard
+and/or mouse.
+.TP
+.SS
+.B --paging
+Connect to the daemon and activate paging.
+Paging displays overview of all virtual desktops.
+.TP
+.B Activation Modes
+.TP
+.SS
+.B --toggle
+Toggle skippy-xd on/off.
+.TP
+.SS
+.B --pivot
+.I KEY
+Activate skippy-xd via pivot mode with the specified pivot key.
+For example in Alt-Tab, Alt is the pivot key,
+required to be held for activation. When the pivot
+key is released, the currently highlighted window is
+selected.
+
+By default, expose and paging activates on toggle mode, while switch activates on pivot mode with Alt as pivot key.
+.TP
+.TP
+.SS
+.B --multi-select
+Multi-select mode. Independent of toggle/pivot modes,
+multi-select mode allows selecting multiple windows/desktops,
+and returns all selected window/desktop IDs, enabling sophisticated scripting.
+.TP
+.B Window Filtering
+.TP
+.SS
+.B --wm-class
+.I CLASS
+Display only windows belonging to the specified WM
+class.
+.TP
+.SS
+.B --wm-title
+.I TITLE
+Display only windows matching the specified title.
+.TP
+.SS
+.B --wm-status
+.I STATUS
+Display only windows with the specified status.
+Valid status values are:
+.RS
+.IP "sticky" 4
+Sticky windows (visible on all desktops)
+.IP "shaded" 4
+Shaded windows
+.IP "minimized" 4
+Minimized windows
+.IP "float" 4
+Floating windows
+.IP "maximized_vert" 4
+Vertically maximized windows
+.IP "maximized_horz" 4
+Horizontally maximized windows
+.IP "maximized" 4
+Fully maximized windows
+.RE
+.TP
+.SS
+.B --desktop
+.I DESKTOP
+Display only windows on the specified virtual
+desktop. Use
+.B -1
+to show windows from all desktops.
+.TP
+.B Navigation
+.TP
+.SS
+.B --prev
+Focus the previous window.
+.TP
+.SS
+.B --next
+Focus the next window.
+.TP
+.B Configuration
+.TP
+.SS
+.B --config
+.I PATH
+Loads config file at specified path.
+.TP
+.SS
+.B --config-reload
+Reloads current config file without changing path.
+.TP
+.B Utilities
+.TP
+.SS
+.B --help
+Display help message.
+.TP
+.SS
+.B --debug-log
+Prints detailed debugging logs.
+.TP
+.B Return Value
+Skippy-xd returns values based on whether it is the activating process:
+.IP
+If the skippy-xd command activated skippy-xd, it is guaranteed to return after the completion of skippy-xd selection, with the window ID (in case of switch and expose) or virtual desktop ID (in case of paging).
+.IP
+If the skippy-xd command did not activate skippy-xd, e.g. with toggling off of expose, or --next invocations of switch, then the command will return immediately with -1.
+.SH FILES
+.TP
+.I ~/.config/skippy-xd/skippy-xd.rc
+User configuration file.
+.TP
+.I /etc/xdg/skippy-xd.rc
+System wide configuration file.
+.SH EXAMPLES
+.SS Starting the Daemon
+.PP
+skippy-xd --start-daemon
+.IP
+Starts the skippy-xd daemon in the background.
+.PP
+skippy-xd --start-daemon --config ~/.config/skippy-xd/skippy-xd.rc
+.IP
+Starts the skippy-xd daemon in the background
+using the specified configuration file.
+.SS Window Switching
+.PP
+skippy-xd --switch --next
+.IP
+Focus on the next window in switch mode.
+.PP
+skippy-xd --switch --prev
+.IP
+Focus on the previous window in switch mode.
+.SS Expose
+.PP
+skippy-xd --expose
+.IP
+Show live preview of all windows on the current desktop.
+.SS Paging
+.PP
+skippy-xd --paging
+.IP
+Display overview of all virtual desktops.
+.SS Filtered Window Selection
+.PP
+skippy-xd --expose --wm-class firefox
+.IP
+Show only Firefox windows in expose mode.
+.PP
+skippy-xd --expose --desktop 1
+.IP
+Show windows only from desktop 1.
+.SS Additional Examples
+.PP
+skippy-xd --expose --pivot Super_L --next
+.IP
+Activate expose via pivot mode with Super_L
+as the pivot key, highlighting the next window.
+.PP
+skippy-xd --expose --desktop -1 --wm-class firefox --wm-status float,maximized_vert --config ~/.config/skippy-xd/other.rc
+.IP
+Show Firefox windows from all desktops that are
+floating or vertically maximized, with custom config file.
+.SH COMPATIBILITY
+.B skippy-xd
+works with any X Window Manager and desktop
+environment. See the project wiki for a comprehensive
+compatibility list:
+.IP
+https://github.com/felixfung/skippy-xd/wiki/Adoption
+.SH SUPPORTED IMAGE FORMATS
+.B skippy-xd
+supports the following image formats for icons, backgrounds:
+.IP
+.B PNG
+.I (with libpng support)
+.IP
+.B JPEG
+.I (with libjpeg support)
+.IP
+.B GIF
+.I (with libgif support)
+.SH FEATURES
+.IP "\\(bu" 2
+Live window preview
+.IP "\\(bu" 2
+Unmapped window preview
+.IP "\\(bu" 2
+MacOS-inspired Exposé view
+.IP "\\(bu" 2
+Virtual desktop overview
+.IP "\\(bu" 2
+Advanced window filtering
+.IP "\\(bu" 2
+Configurable invocation, activation, key bindings, behaviour
+.IP "\\(bu" 2
+Scriptable and modular by design
+.SH SEE ALSO
+.B skippy-xd
+can be set up for many advanced customizations and set ups,
+including invocation method, scripting, dashboard set up,
+multimonitor set up, config file options, combination with other apps.
+For detailed usage instructions, advanced tips, and configuration guidance,
+please see:
+.IP
+Wiki: https://github.com/felixfung/skippy-xd/wiki/Advanced-Uses-and-Special-Set-Ups
+.IP
+YouTube: https://www.youtube.com/@skippy-xd
+.SH AUTHORS
+.B skippy-xd
+was originally developed by Hyriand and is currently
+maintained by Felix Fung.
+.SH LICENSE
+.B skippy-xd
+is released under the GNU General Public License
+v2.0 or later. See the COPYING file included with
+the distribution for details.
+.SH BUGS
+For bug reports and feature requests, visit:
+.IP
+https://github.com/felixfung/skippy-xd/issues
+https://github.com/felixfung/skippy-xd/discussions
+.SH VERSION

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-v0.10.6 (2026.1.4) - 'Brainrot 67' Edition
+v0.10.6-testing (2026.1.4) - 'Brainrot 67' Edition

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-v0.10.6-testing (2026.1.4) - 'Brainrot 67' Edition
+v0.10.6 (2026.1.4) - 'Brainrot 67' Edition


### PR DESCRIPTION
Changes:

Version extraction now portable: replaced grep -oP with sed -E for compatibility across all containers
RPM workflow: strips version suffixes (e.g., -test) automatically for spec file and tarball names
All workflows use consistent if/else logic for tag vs fallback version detection

Tested:

✅ AppImage builds and uploads
✅ Debian amd64 + i386 builds and uploads
✅ RPM builds and uploads (fixed Fedora container issues)