### PR TITLE
Object life-cycle fix for coordinates and pixmaps

### DIFF
--- a/skippy-xd.rc
+++ b/skippy-xd.rc
@@ -73,8 +73,8 @@ exposeCycleDesktops = false
 # Relative minimal pixel distance between windows
 distance = 50
 
-# Whether to show the window bigger than its original size
-allowUpscale = false
+# Fill screen by upscaling windows
+upscaleWindows = false
 
 [appearance]
 

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -359,10 +359,13 @@ clientwin_update2_desktop(session_t *ps, MainWin *mw, ClientWin *cw) {
 
 static inline bool
 clientwin_update2_filled(session_t *ps, MainWin *mw, ClientWin *cw) {
+	float scale = cw->paneltype == WINTYPE_PANEL
+			   || cw->paneltype == WINTYPE_DESKTOP
+		? 1.0f : cw->mainwin->multiplier;
 	int width = cw->mini.width > 0 ? cw->mini.width
-				: cw->src.width * cw->mainwin->multiplier;
+				: cw->src.width * scale;
 	int height = cw->mini.height > 0 ? cw->mini.height
-				: cw->src.height * cw->mainwin->multiplier;
+				: cw->src.height * scale;
 
 	if (cw->pict_filled)
 		free_pictw(ps, &cw->pict_filled);
@@ -377,10 +380,13 @@ clientwin_update2_filled(session_t *ps, MainWin *mw, ClientWin *cw) {
 
 static inline bool
 clientwin_update2_icon(session_t *ps, MainWin *mw, ClientWin *cw) {
+	float scale = cw->paneltype == WINTYPE_PANEL
+			   || cw->paneltype == WINTYPE_DESKTOP
+		? 1.0f : cw->mainwin->multiplier;
 	int width = cw->mini.width > 0 ? cw->mini.width
-				: cw->src.width * cw->mainwin->multiplier;
+				: cw->src.width * scale;
 	int height = cw->mini.height > 0 ? cw->mini.height
-				: cw->src.height * cw->mainwin->multiplier;
+				: cw->src.height * scale;
 
 	if (cw->icon_pict_filled)
 		free_pictw(ps, &cw->icon_pict_filled);

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -359,12 +359,17 @@ clientwin_update2_desktop(session_t *ps, MainWin *mw, ClientWin *cw) {
 
 static inline bool
 clientwin_update2_filled(session_t *ps, MainWin *mw, ClientWin *cw) {
+	int width = cw->mini.width > 0 ? cw->mini.width
+				: cw->src.width * cw->mainwin->multiplier;
+	int height = cw->mini.height > 0 ? cw->mini.height
+				: cw->src.height * cw->mainwin->multiplier;
+
 	if (cw->pict_filled)
 		free_pictw(ps, &cw->pict_filled);
 	cw->pict_filled = simg_postprocess(ps,
 			clone_pictw(ps, ps->o.fillSpec.img),
 			ps->o.fillSpec.mode,
-			cw->mini.width, cw->mini.height,
+			width, height,
 			ps->o.fillSpec.alg, ps->o.fillSpec.valg,
 			&ps->o.fillSpec.c);
 	return cw->pict_filled;
@@ -372,13 +377,18 @@ clientwin_update2_filled(session_t *ps, MainWin *mw, ClientWin *cw) {
 
 static inline bool
 clientwin_update2_icon(session_t *ps, MainWin *mw, ClientWin *cw) {
+	int width = cw->mini.width > 0 ? cw->mini.width
+				: cw->src.width * cw->mainwin->multiplier;
+	int height = cw->mini.height > 0 ? cw->mini.height
+				: cw->src.height * cw->mainwin->multiplier;
+
 	if (cw->icon_pict_filled)
 		free_pictw(ps, &cw->icon_pict_filled);
 
 	cw->icon_pict_filled = simg_postprocess(ps,
 			clone_pictw(ps, cw->icon_pict_filler),
 			ps->o.iconFillSpec.mode,
-			cw->mini.width, cw->mini.height,
+			width, height,
 			ps->o.iconFillSpec.alg, ps->o.iconFillSpec.valg,
 			&ps->o.iconFillSpec.c);
 	return cw->icon_pict_filled;
@@ -424,6 +434,8 @@ clientwin_destroy(ClientWin *cw, bool destroyed) {
 	free_picture(ps, &cw->destination);
 	free_picture(ps, &cw->shadow);
 	free_pixmap(ps, &cw->pixmap);
+	cw->pixmap_width = 0;
+	cw->pixmap_height = 0;
 	free_pixmap(ps, &cw->cpixmap);
 	free_pictw(ps, &cw->icon_pict);
 	free_pictw(ps, &cw->icon_pict_filler);
@@ -710,6 +722,16 @@ void clientwin_round_corners(ClientWin *cw) {
 
 void clientwin_prepmove(ClientWin *cw)
 {
+	int width = MAX(cw->src.width, cw->src.width * cw->mainwin->multiplier);
+	int height = MAX(cw->src.height, cw->src.height * cw->mainwin->multiplier);
+
+	if (width <= 0 || height <= 0)
+		return;
+
+	if (cw->pixmap && cw->destination
+			&& cw->pixmap_width == width && cw->pixmap_height == height)
+		return;
+
 	if (cw->pixmap)
 		XFreePixmap(cw->mainwin->ps->dpy, cw->pixmap);
 
@@ -717,12 +739,14 @@ void clientwin_prepmove(ClientWin *cw)
 		XRenderFreePicture(cw->mainwin->ps->dpy, cw->destination);
 
 	cw->pixmap = XCreatePixmap(cw->mainwin->ps->dpy, cw->mini.window,
-			cw->src.width, cw->src.height, cw->mainwin->depth);
+			width, height, cw->mainwin->depth);
 	XSetWindowBackgroundPixmap(cw->mainwin->ps->dpy,
 			cw->mini.window, cw->pixmap);
 
 	cw->destination = XRenderCreatePicture(cw->mainwin->ps->dpy,
 			cw->pixmap, cw->mini.format, 0, 0);
+	cw->pixmap_width = width;
+	cw->pixmap_height = height;
 }
 
 void
@@ -787,6 +811,8 @@ clientwin_unmap(ClientWin *cw) {
 	free_damage(ps, &cw->damage);
 	free_picture(ps, &cw->destination);
 	free_pixmap(ps, &cw->pixmap);
+	cw->pixmap_width = 0;
+	cw->pixmap_height = 0;
 
 	XUnmapWindow(ps->dpy, cw->mini.window);
 	XSetWindowBackgroundPixmap(ps->dpy, cw->mini.window, None);

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -45,6 +45,7 @@ struct _clientwin_t {
 	pictw_t *icon_pict_filler;
 
 	SkippyWindow mini;
+	int pixmap_width, pixmap_height;
 
 	Pixmap pixmap;
 	Picture origin, destination, shadow;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1279,7 +1279,6 @@ skippy_activate(MainWin *mw, enum layoutmode layout, Window leader)
 	foreach_dlist(mw->clients) {
 		ClientWin *cw = iter->data;
 		clientwin_update3(cw);
-		clientwin_update2(cw);
 		cw->paneltype = wm_identify_panel(mw->ps, cw->wid_client);
 	}
 
@@ -1294,6 +1293,7 @@ skippy_activate(MainWin *mw, enum layoutmode layout, Window leader)
 		cw->src.y -= mw->y;
 		cw->x *= mw->multiplier;
 		cw->y *= mw->multiplier;
+		clientwin_update2(cw);
 	}
 
 	foreach_dlist(mw->panels) {

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1019,7 +1019,7 @@ calculatePanelBorders(MainWin *mw,
 
 static void
 init_multiplier(MainWin *mw, unsigned int newwidth, unsigned int newheight,
-		bool allowUpscale, int gap)
+		bool upscaleWindows, int gap)
 {
 	int x1=0, y1=0, x2=0, y2=0;
 	calculatePanelBorders(mw, &x1, &y1, &x2, &y2);
@@ -1032,7 +1032,7 @@ init_multiplier(MainWin *mw, unsigned int newwidth, unsigned int newheight,
 		multiplier = (float) (mw->height - gap * mw->distance
 				- y1 - y2) / newheight;
 
-	if (!allowUpscale)
+	if (!upscaleWindows)
 		multiplier = MIN(multiplier, 1.0f);
 
 	int xoff = (mw->width - x1 - x2 - (float)(newwidth
@@ -1052,7 +1052,7 @@ init_layout(MainWin *mw, enum layoutmode layout, Window leader)
 	if (mw->clientondesktop)
 		layout_run(mw, mw->clientondesktop, &newwidth, &newheight, layout);
 
-	init_multiplier(mw, newwidth, newheight, mw->ps->o.allowUpscale, 2);
+	init_multiplier(mw, newwidth, newheight, mw->ps->o.upscaleWindows, 2);
 	init_focus(mw, layout, leader);
 }
 
@@ -2730,7 +2730,7 @@ load_config_file(session_t *ps)
     config_get_int_wrap(config, "layout", "switchWaitDuration", &ps->o.switchWaitDuration, 0, 2000);
     config_get_bool_wrap(config, "layout", "switchCycleDuringWait", &ps->o.switchCycleDuringWait);
     config_get_int_wrap(config, "layout", "distance", &ps->o.distance, 5, INT_MAX);
-    config_get_bool_wrap(config, "layout", "allowUpscale", &ps->o.allowUpscale);
+    config_get_bool_wrap(config, "layout", "upscaleWindows", &ps->o.upscaleWindows);
 
     config_get_int_wrap(config, "appearance", "animationDuration", &ps->o.animationDuration, 0, 2000);
     config_get_int_wrap(config, "appearance", "animationRefresh", &ps->o.animationRefresh, 1, 200);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1280,6 +1280,8 @@ skippy_activate(MainWin *mw, enum layoutmode layout, Window leader)
 		ClientWin *cw = iter->data;
 		clientwin_update3(cw);
 		cw->paneltype = wm_identify_panel(mw->ps, cw->wid_client);
+		if (cw->paneltype == WINTYPE_PANEL || cw->paneltype == WINTYPE_DESKTOP)
+			clientwin_update2(cw);
 	}
 
 	if (layout == LAYOUTMODE_PAGING)
@@ -1293,7 +1295,8 @@ skippy_activate(MainWin *mw, enum layoutmode layout, Window leader)
 		cw->src.y -= mw->y;
 		cw->x *= mw->multiplier;
 		cw->y *= mw->multiplier;
-		clientwin_update2(cw);
+		if (cw->paneltype != WINTYPE_PANEL && cw->paneltype != WINTYPE_DESKTOP)
+			clientwin_update2(cw);
 	}
 
 	foreach_dlist(mw->panels) {

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -217,7 +217,7 @@ typedef struct {
 	bool switchCycleDesktops;
 	bool exposeCycleDesktops;
 	int distance;
-	bool allowUpscale;
+	bool upscaleWindows;
 
 	int animationDuration;;
 	int animationRefresh;;
@@ -307,7 +307,7 @@ typedef struct {
 	.switchCycleDesktops = false, \
 	.exposeCycleDesktops = false, \
 	.distance = 50, \
-	.allowUpscale = false, \
+	.upscaleWindows = false, \
 \
 	.animationDuration = 200, \
 	.animationRefresh = 60, \


### PR DESCRIPTION
Window coordinates and pixmaps object life-cycle fix.

Notably desktop windows is displayed properly.

Pixmap life-cycle fix means `layout/allowUpscale` pixmap now behaves properly.

Rename `layout/allowUpscale` -> `layout/upscaleWindows`.

In addition, pixmap optimization means animation is tiny bit smoother.

@musqz can you please see if this PR makes any difference to #433?