### PR TITLE
XD layout -> rect layout and compactrect layout

### DIFF
--- a/skippy-xd.rc
+++ b/skippy-xd.rc
@@ -60,9 +60,10 @@ verticalPanelAlignment = mid
 
 [layout]
 
-# xd: row-to-row layout
 # cosmos: position preserving layout
-switchLayout = xd
+# rect: row-to-row layout
+# compactrect: compactized row-to-row layout
+switchLayout = rect
 exposeLayout = cosmos
 
 # Wait time in ms before displaying switch previews

--- a/src/layout.c
+++ b/src/layout.c
@@ -103,7 +103,10 @@ layout_xd(MainWin *mw, dlist *windows,
 	foreach_dlist (windows) {
 		ClientWin *cw = (ClientWin*) iter->data;
 		if (!cw->mode) continue;
-		dlist *slot_iter = dlist_first(slots);
+		dlist *slot_iter = NULL;
+		if ((mw->ps->o.mode == PROGMODE_SWITCH && mw->ps->o.switch_compact)
+		 || (mw->ps->o.mode == PROGMODE_EXPOSE && mw->ps->o.expose_compact))
+			slot_iter = dlist_first(slots);
 		for (; slot_iter; slot_iter = slot_iter->next) {
 			dlist *slot = (dlist *) slot_iter->data;
 			// Calculate current total height of slot

--- a/src/layout.c
+++ b/src/layout.c
@@ -62,8 +62,7 @@ void layout_run(MainWin *mw, dlist *windows,
 		dlist *sorted_windows = dlist_dup(windows);
 		dlist_sort(sorted_windows, sort_cw_by_id, 0);
 		dlist_sort(sorted_windows, sort_cw_by_row, 0);
-		if (mw->ps->o.exposeLayout == LAYOUT_COSMOS)
-			layout_cosmos(mw, sorted_windows, total_width, total_height);
+		layout_cosmos(mw, sorted_windows, total_width, total_height);
 		dlist_free(sorted_windows);
 	}
 	else {

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -2761,19 +2761,28 @@ load_config_file(session_t *ps)
 			if (strcmp(s,"cosmos") == 0) {
 				ps->o.switchLayout = LAYOUT_COSMOS;
 			}
-			else if (strcmp(s,"xd") == 0) {
+			else if (strcmp(s,"rect") == 0) {
 				ps->o.switchLayout = LAYOUT_XD;
+				ps->o.switch_compact = false;
+			}
+			else if (strcmp(s,"compactrect") == 0) {
+				ps->o.switchLayout = LAYOUT_XD;
+				ps->o.switch_compact = true;
 			}
 			else {
 				printfef(true, "(): switchLayout \"%s\" not found. Valid switchLayout are:",
 						s);
-				printfef(true, "(): xd");
-				printfef(true, "(): cosmos (default)");
+				printfef(true, "(): rect (default)");
+				printfef(true, "(): compactrect");
+				printfef(true, "(): cosmos");
 				ps->o.switchLayout = LAYOUT_XD;
+				ps->o.switch_compact = false;
 			}
 		}
-		else
+		else {
 			ps->o.switchLayout = LAYOUT_XD;
+			ps->o.switch_compact = false;
+		}
     }
 	{
 		const char *s = config_get(config, "layout", "exposeLayout", NULL);
@@ -2781,19 +2790,28 @@ load_config_file(session_t *ps)
 			if (strcmp(s,"cosmos") == 0) {
 				ps->o.exposeLayout = LAYOUT_COSMOS;
 			}
-			else if (strcmp(s,"xd") == 0) {
+			else if (strcmp(s,"rect") == 0) {
 				ps->o.exposeLayout = LAYOUT_XD;
+				ps->o.expose_compact = false;
+			}
+			else if (strcmp(s,"compactrect") == 0) {
+				ps->o.exposeLayout = LAYOUT_XD;
+				ps->o.expose_compact = true;
 			}
 			else {
 				printfef(true, "(): exposeLayout \"%s\" not found. Valid exposeLayout are:",
 						s);
-				printfef(true, "(): xd");
+				printfef(true, "(): rect");
+				printfef(true, "(): compactrect");
 				printfef(true, "(): cosmos (default)");
 				ps->o.exposeLayout = LAYOUT_COSMOS;
+				ps->o.expose_compact = false;
 			}
 		}
-		else
+		else {
 			ps->o.exposeLayout = LAYOUT_COSMOS;
+			ps->o.expose_compact = false;
+		}
     }
     config_get_bool_wrap(config, "layout", "switchCycleDesktops", &ps->o.switchCycleDesktops);
     config_get_bool_wrap(config, "layout", "exposeCycleDesktops", &ps->o.exposeCycleDesktops);

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -213,7 +213,9 @@ typedef struct {
 	char *desktops;
 
 	int switchLayout;
+	bool switch_compact;
 	int exposeLayout;
+	bool expose_compact;
 	int switchWaitDuration;
 	bool switchCycleDuringWait;
 	bool switchCycleDesktops;
@@ -309,7 +311,9 @@ typedef struct {
 	.wm_status = NULL, \
 \
 	.switchLayout = LAYOUT_XD, \
+	.switch_compact = false, \
 	.exposeLayout = LAYOUT_COSMOS, \
+	.expose_compact = false, \
 	.switchWaitDuration = 100, \
 	.switchCycleDuringWait = false, \
 	.switchCycleDesktops = false, \


### PR DESCRIPTION
The default layout for switch (Alt-Tab) is XD, which is roughly arranges windows row-to-row, left-to-right, but compactize the layout by slotting windows into empty space when available.

This compactizing optimizes screen estate, at the expense of confounding window ordering.

This PR provides users config option to choose whether to perform compactization, through the layout config options.

Rename original "xd" layout into "rect" and "compactrect", the latter performing compactization.

This PR will go to next version, which will focus on improving layouts.