### PR TITLE
feat: multi-monitor XRandr support with EWMH _NET_WORKAREA panel deta…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ SRCS_RAW = skippy wm dlist mainwin clientwin layout focus config tooltip img img
 PACKAGES = x11 xft xrender xcomposite xdamage xfixes xext
 
 # === Options ===
+ifeq "${CFG_NO_XRANDR}" ""
+	CPPFLAGS += -DCFG_XRANDR
+	LIBS += -lXrandr
+endif
+
 ifeq "${CFG_NO_XINERAMA}" ""
 	CPPFLAGS += -DCFG_XINERAMA
 	PACKAGES += xinerama

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -19,10 +19,6 @@
 
 #include "skippy.h"
 
-#ifdef CFG_XRANDR
-#include <X11/extensions/Xrandr.h>
-#endif /* CFG_XRANDR */
-
 void
 XRenderTintBorder(session_t *ps,
 		Drawable drawable,
@@ -188,12 +184,6 @@ static bool
 mainwin_detect_monitor_xrandr(MainWin *mw) {
 	session_t *ps = mw->ps;
 	Display *dpy = ps->dpy;
-
-	int major, minor;
-	if (!XRRQueryVersion(dpy, &major, &minor)) {
-		printfdf(false, "(): XRandr not available");
-		return false;
-	}
 
 	Window root = ps->root;
 	XRRScreenResources *res = XRRGetScreenResources(dpy, root);

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -19,6 +19,10 @@
 
 #include "skippy.h"
 
+#ifdef CFG_XRANDR
+#include <X11/extensions/Xrandr.h>
+#endif /* CFG_XRANDR */
+
 void
 XRenderTintBorder(session_t *ps,
 		Drawable drawable,
@@ -174,6 +178,93 @@ find_argb_visual (Display *dpy, int scr)
 	XFree (xvi);
 	return visual;
 }
+
+#ifdef CFG_XRANDR
+/**
+ * Detect monitors using XRandr and set current monitor based on cursor position.
+ * Returns true if monitor detected, false otherwise.
+ */
+static bool
+mainwin_detect_monitor_xrandr(MainWin *mw) {
+	session_t *ps = mw->ps;
+	Display *dpy = ps->dpy;
+
+	int major, minor;
+	if (!XRRQueryVersion(dpy, &major, &minor)) {
+		printfdf(false, "(): XRandr not available");
+		return false;
+	}
+
+	Window root = ps->root;
+	XRRScreenResources *res = XRRGetScreenResources(dpy, root);
+	if (!res) {
+		printfdf(false, "(): XRRGetScreenResources failed");
+		return false;
+	}
+
+	/* Get cursor position */
+	int root_x, root_y;
+	Window dummy_w;
+	int dummy_i;
+	unsigned int dummy_u;
+	XQueryPointer(dpy, root, &dummy_w, &dummy_w, &root_x, &root_y, &dummy_i, &dummy_i, &dummy_u);
+
+	/* Find monitor containing cursor */
+	bool found = false;
+	for (int i = 0; i < res->ncrtc; i++) {
+		XRRCrtcInfo *crtc_info = XRRGetCrtcInfo(dpy, res, res->crtcs[i]);
+		if (!crtc_info) continue;
+
+		if (crtc_info->mode != None && crtc_info->noutput > 0) {
+			int x = crtc_info->x;
+			int y = crtc_info->y;
+			int w = crtc_info->width;
+			int h = crtc_info->height;
+
+			if (!found && root_x >= x && root_x < x + w && root_y >= y && root_y < y + h) {
+				mw->monitor_x = x;
+				mw->monitor_y = y;
+				mw->monitor_width = w;
+				mw->monitor_height = h;
+				found = true;
+				printfdf(false, "(): XRandr monitor %dx%d+%d+%d (cursor at %d,%d)",
+					w, h, x, y, root_x, root_y);
+			}
+		}
+		XRRFreeCrtcInfo(crtc_info);
+	}
+
+	XRRFreeScreenResources(res);
+
+	if (!found) {
+		/* Fallback: use first active CRTC */
+		res = XRRGetScreenResources(dpy, root);
+		if (res) {
+			for (int i = 0; i < res->ncrtc; i++) {
+				XRRCrtcInfo *crtc_info = XRRGetCrtcInfo(dpy, res, res->crtcs[i]);
+				if (!crtc_info) continue;
+
+				if (crtc_info->mode != None && crtc_info->noutput > 0) {
+					mw->monitor_x = crtc_info->x;
+					mw->monitor_y = crtc_info->y;
+					mw->monitor_width = crtc_info->width;
+					mw->monitor_height = crtc_info->height;
+					found = true;
+					printfdf(false, "(): XRandr fallback monitor %dx%d+%d+%d",
+						crtc_info->width, crtc_info->height,
+						crtc_info->x, crtc_info->y);
+					XRRFreeCrtcInfo(crtc_info);
+					break;
+				}
+				XRRFreeCrtcInfo(crtc_info);
+			}
+			XRRFreeScreenResources(res);
+		}
+	}
+
+	return found;
+}
+#endif /* CFG_XRANDR */
 
 MainWin *
 mainwin_create(session_t *ps) {
@@ -509,59 +600,93 @@ mainwin_render_borders(MainWin *mw)
 void
 mainwin_update(MainWin *mw)
 {
-#ifdef CFG_XINERAMA
 	session_t * const ps = mw->ps;
+	Display *dpy = ps->dpy;
+	bool monitor_detected = false;
 
-	XineramaScreenInfo *iter;
-	int i;
-	Window dummy_w;
-	int root_x, root_y, dummy_i;
-	unsigned int dummy_u;
+	/* Initialize monitor fields to root window as fallback */
+	mw->monitor_x = 0;
+	mw->monitor_y = 0;
+	XWindowAttributes rootattr;
+	XGetWindowAttributes(dpy, ps->root, &rootattr);
+	mw->monitor_width = rootattr.width;
+	mw->monitor_height = rootattr.height;
 
-	if (ps->xinfo.xinerama_exist && XineramaIsActive(ps->dpy)) {
+#ifdef CFG_XRANDR
+	/* Try XRandr first (modern X11 standard) */
+	if (mainwin_detect_monitor_xrandr(mw)) {
+		monitor_detected = true;
+		printfdf(false, "(): Using XRandr monitor detection");
+	}
+#endif /* CFG_XRANDR */
+
+#ifdef CFG_XINERAMA
+	/* Fall back to Xinerama if XRandr failed */
+	if (!monitor_detected && ps->xinfo.xinerama_exist && XineramaIsActive(dpy)) {
+		XineramaScreenInfo *iter;
+		int i;
+		Window dummy_w;
+		int root_x, root_y, dummy_i;
+		unsigned int dummy_u;
+
 		if(mw->xin_info)
 			XFree(mw->xin_info);
-		mw->xin_info = XineramaQueryScreens(ps->dpy, &mw->xin_screens);
+		mw->xin_info = XineramaQueryScreens(dpy, &mw->xin_screens);
 		printfdf(false, "(): Xinerama is enabled (%d screens).", mw->xin_screens);
-	}
-	
-	if(! mw->xin_info || ! mw->xin_screens)
-	{
-		mainwin_update_background(mw);
-		return;
-	}
-	
-	printfdf(false, "(): XINERAMA --> querying pointer... ");
-	XQueryPointer(ps->dpy, ps->root, &dummy_w, &dummy_w, &root_x, &root_y, &dummy_i, &dummy_i, &dummy_u);
-	printfdf(false, "(): XINERAMA +%i+%i\n", root_x, root_y);
-	
-	printfdf(false, "(): XINERAMA --> figuring out which screen we're on... ");
-	iter = mw->xin_info;
-	for(i = 0; i < mw->xin_screens; ++i)
-	{
-		if(root_x >= iter->x_org && root_x < iter->x_org + iter->width &&
-		   root_y >= iter->y_org && root_y < iter->y_org + iter->height)
-		{
-			printfdf(false, "(): XINERAMA screen %i %ix%i+%i+%i\n", iter->screen_number, iter->width, iter->height, iter->x_org, iter->y_org);
-			break;
-		}
-		iter++;
-	}
-	if(i == mw->xin_screens)
-	{
-		printfdf(false, "(): XINERAMA unknown\n");
-		return;
-	}
-	mw->x = iter->x_org;
-	mw->y = iter->y_org;
-	mw->width = iter->width;
-	mw->height = iter->height;
-	XMoveResizeWindow(ps->dpy, mw->window, iter->x_org, iter->y_org, mw->width, mw->height);
 
-	mw->xin_active = iter;
-	if (!ps->o.showOnlyCurrentMonitor)
-		mw->xin_active = 0;
+		if(mw->xin_info && mw->xin_screens)
+		{
+			printfdf(false, "(): XINERAMA --> querying pointer... ");
+			XQueryPointer(dpy, ps->root, &dummy_w, &dummy_w, &root_x, &root_y, &dummy_i, &dummy_i, &dummy_u);
+			printfdf(false, "(): XINERAMA +%i+%i\n", root_x, root_y);
+
+			printfdf(false, "(): XINERAMA --> figuring out which screen we're on... ");
+			iter = mw->xin_info;
+			for(i = 0; i < mw->xin_screens; ++i)
+			{
+				if(root_x >= iter->x_org && root_x < iter->x_org + iter->width &&
+				   root_y >= iter->y_org && root_y < iter->y_org + iter->height)
+				{
+					printfdf(false, "(): XINERAMA screen %i %ix%i+%i+%i\n",
+						iter->screen_number, iter->width, iter->height,
+						iter->x_org, iter->y_org);
+					mw->monitor_x = iter->x_org;
+					mw->monitor_y = iter->y_org;
+					mw->monitor_width = iter->width;
+					mw->monitor_height = iter->height;
+					monitor_detected = true;
+					break;
+				}
+				iter++;
+			}
+			if(i == mw->xin_screens)
+			{
+				printfdf(false, "(): XINERAMA unknown screen, using first");
+				iter = mw->xin_info;
+				mw->monitor_x = iter->x_org;
+				mw->monitor_y = iter->y_org;
+				mw->monitor_width = iter->width;
+				mw->monitor_height = iter->height;
+				monitor_detected = true;
+			}
+
+			mw->xin_active = iter;
+			if (!ps->o.showOnlyCurrentMonitor)
+				mw->xin_active = 0;
+		}
+	}
 #endif /* CFG_XINERAMA */
+
+	/* Update mainwin geometry to current monitor */
+	mw->x = mw->monitor_x;
+	mw->y = mw->monitor_y;
+	mw->width = mw->monitor_width;
+	mw->height = mw->monitor_height;
+	XMoveResizeWindow(dpy, mw->window, mw->x, mw->y, mw->width, mw->height);
+
+	printfdf(false, "(): Active monitor: %dx%d+%d+%d",
+		mw->width, mw->height, mw->x, mw->y);
+
 	mainwin_update_background(mw);
 }
 

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -81,9 +81,6 @@ struct _mainwin_t {
 	int monitor_x, monitor_y;
 	int monitor_width, monitor_height;
 
-#ifdef CFG_XRANDR
-	int xrandr_event_base, xrandr_error_base;
-#endif /* CFG_XRANDR */
 
 #ifdef CFG_XINERAMA
 	int xin_screens;

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -77,6 +77,14 @@ struct _mainwin_t {
 	bool refocus;
 	bool mapped;
 
+	/// @brief Current monitor bounds (detected via XRandr or Xinerama)
+	int monitor_x, monitor_y;
+	int monitor_width, monitor_height;
+
+#ifdef CFG_XRANDR
+	int xrandr_event_base, xrandr_error_base;
+#endif /* CFG_XRANDR */
+
 #ifdef CFG_XINERAMA
 	int xin_screens;
 	XineramaScreenInfo *xin_info, *xin_active;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -952,69 +952,85 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 		dlist_sort(mw->focuslist, sort_cw_by_column, 0);
 }
 
+/**
+ * Get workarea from EWMH _NET_WORKAREA property for current desktop.
+ * Returns true if successful, false otherwise.
+ * Workarea format: left, top, width, height for each desktop.
+ */
+static bool
+get_workarea(session_t *ps, int *work_x, int *work_y, int *work_w, int *work_h) {
+	Atom actual_type;
+	int actual_format;
+	unsigned long nitems, bytes_after;
+	unsigned char *data = NULL;
+
+	Atom _NET_WORKAREA = XInternAtom(ps->dpy, "_NET_WORKAREA", False);
+	int status = XGetWindowProperty(ps->dpy, ps->root, _NET_WORKAREA,
+			0, 4, False, XA_CARDINAL,
+			&actual_type, &actual_format, &nitems, &bytes_after, &data);
+
+	if (status != Success || !data || nitems < 4) {
+		if (data) XFree(data);
+		return false;
+	}
+
+	long *values = (long *)data;
+	*work_x = (int)values[0];
+	*work_y = (int)values[1];
+	*work_w = (int)values[2];
+	*work_h = (int)values[3];
+
+	XFree(data);
+	printfdf(false, "(): _NET_WORKAREA: %dx%d+%d+%d", *work_w, *work_h, *work_x, *work_y);
+	return true;
+}
+
 static void
 calculatePanelBorders(MainWin *mw,
 		int *x1, int *y1, int *x2, int *y2) {
-	if (!mw->ps->o.panel_reserveSpace)
+	session_t *ps = mw->ps;
+
+	printfdf(false, "(): calculatePanelBorders called, panel_reserveSpace=%d", ps->o.panel_reserveSpace);
+	printfdf(false, "(): monitor: %dx%d+%d+%d", mw->monitor_width, mw->monitor_height, mw->monitor_x, mw->monitor_y);
+
+	/* Default: no panel reservation */
+	*x1 = *y1 = 0;
+	*x2 = mw->width - mw->monitor_width;
+	*y2 = mw->height - mw->monitor_height;
+
+	if (!ps->o.panel_reserveSpace) {
+		printfdf(false, "(): panel_reserveSpace disabled, skipping");
 		return;
-
-	// use heuristics to find panel borders
-	// e.g. a panel on the bottom
-	*x1 = 0;
-	*y1 = 0;
-	*x2 = mw->width;
-	*y2 = mw->height;
-
-	foreach_dlist(mw->panels) {
-		ClientWin *cw = iter->data;
-		if (cw->paneltype != WINTYPE_PANEL)
-			continue;
-
-#ifdef CFG_XINERAMA
-			int midx = cw->src.x + cw->src.width / 2;
-			int midy = cw->src.y + cw->src.height / 2;
-
-			XineramaScreenInfo *xiter = mw->xin_info;
-			for (int i=0; i<mw->xin_screens; i++)
-			{
-				if(xiter->x_org <= midx && midx < xiter->x_org + xiter->width &&
-				   xiter->y_org <= midy && midy < xiter->y_org + xiter->height)
-				{
-					cw->src.x -= xiter->x_org;
-					cw->src.y -= xiter->y_org;
-				}
-				xiter++;
-			}
-#endif /* CFG_XINERAMA */
-
-		// assumed horizontal panel
-		if (cw->src.width >= cw->src.height) {
-			// assumed top panel
-			if (cw->src.y < mw->y + mw->height / 2.0) {
-				*y1 = MAX(*y1, cw->src.y + cw->src.height);
-			}
-			// assumed bottom panel
-			else {
-				*y2 = MIN(*y2, cw->src.y);
-			}
-		}
-		// assumed vertical panel
-		else {
-			// assumed left panel
-			if (cw->src.x < mw->x + mw->width / 2.0) {
-				*x1 = MAX(*x1, cw->src.x + cw->src.width);
-			}
-			// assumed right panel
-			else {
-				*x2 = MIN(*x2, cw->src.x);
-			}
-		}
 	}
 
-	*x2 = mw->width - *x2;
-	*y2 = mw->height - *y2;
+	/* Get current monitor bounds */
+	int mon_x = mw->monitor_x;
+	int mon_y = mw->monitor_y;
+	int mon_w = mw->monitor_width;
+	int mon_h = mw->monitor_height;
 
-	printfdf(false,"(): panel framing calculations: (%d,%d) (%d,%d)", *x1, *y1, *x2, *y2);
+	/* Try to get workarea from EWMH _NET_WORKAREA */
+	int work_x, work_y, work_w, work_h;
+	if (get_workarea(ps, &work_x, &work_y, &work_w, &work_h)) {
+		/* Intersect workarea with current monitor */
+		int left = MAX(mon_x, work_x);
+		int top = MAX(mon_y, work_y);
+		int right = MIN(mon_x + mon_w, work_x + work_w);
+		int bottom = MIN(mon_y + mon_h, work_y + work_h);
+
+		/* Calculate reserved space (panels) */
+		*x1 = left - mon_x;                    /* Left panel reserve */
+		*y1 = top - mon_y;                    /* Top panel reserve */
+		*x2 = (mon_x + mon_w) - right;        /* Right panel reserve */
+		*y2 = (mon_y + mon_h) - bottom;       /* Bottom panel reserve */
+
+		printfdf(false, "(): workarea: monitor %dx%d+%d+%d, workarea %dx%d+%d+%d",
+			mon_w, mon_h, mon_x, mon_y, work_w, work_h, work_x, work_y);
+		printfdf(false, "(): panel reserves: left=%d, top=%d, right=%d, bottom=%d",
+			*x1, *y1, *x2, *y2);
+	} else {
+		printfdf(false, "(): _NET_WORKAREA not available, no panel reservation");
+	}
 }
 
 static void

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -2354,6 +2354,14 @@ init_xexts(session_t *ps) {
 			(ps->xinfo.xinerama_exist ? "yes": "no"));
 #endif /* CFG_XINERAMA */
 
+#ifdef CFG_XRANDR
+	{
+		int major, minor;
+		if (!XRRQueryVersion(dpy, &major, &minor))
+			printfef(true, "(): XRandr extension not found.");
+	}
+#endif /* CFG_XRANDR */
+
 	if(!XDamageQueryExtension(dpy,
 				&ps->xinfo.damage_ev_base, &ps->xinfo.damage_err_base)) {
 		printfef(true, "(): FATAL: XDamage extension not found.");

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -48,6 +48,9 @@
 #ifdef CFG_XINERAMA
 # include <X11/extensions/Xinerama.h>
 #endif
+#ifdef CFG_XRANDR
+# include <X11/extensions/Xrandr.h>
+#endif
 
 #include <sys/types.h>
 #include <sys/time.h>


### PR DESCRIPTION
Was running skippy-xd on multi monitor desktop with Openbox, L shaped layout and vertical lateral panels ( yes not normal, I know ).
Preview was crammed into a one pixel wide hidden area on the margin. 
So I engaged AI tools and together we got to this. Using XRandr libraries to get a better view of the monitor layouts now it allows a correct display of the preview.
Feel free to test and see if it fits.