### PR TITLE
Fix --start-daemon error for FreeBSD

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -3179,7 +3179,7 @@ int main(int argc, char *argv[]) {
 
 		{
 			char *buf[BUF_LEN];
-			while (read(ps->fd_pipe, buf, sizeof(buf)))
+			while (read(ps->fd_pipe, buf, sizeof(buf)) > 0)
 				continue;
 			printfdf(false, "(): Finished flushing pipe \"%s\".", pipePath);
 		}


### PR DESCRIPTION
Use 'skippy-xd --start-daemon' on FreeBSD will be stuck in an infinite loop.
I found that the error is caused by improperly handling the return value of read().
So please review and merge.  

I'm realy impressed by your changes to skippy-xd.Thank you for your efforts.