### PR TITLE
fix: bundle non-core shared libs into AppImage

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -56,6 +56,26 @@ jobs:
             PREFIX=/usr \
             MANDIR=/usr/share/man/man1
 
+      - name: Bundle shared libraries
+        run: |
+          mkdir -p skippy-xd.AppDir/usr/lib
+          BIN=skippy-xd.AppDir/usr/bin/skippy-xd
+          # Libraries that must be provided by the host (glibc, C++ runtime,
+          # core X11/GL/driver stack). Everything else the binary links is
+          # copied in so the AppImage is self-contained across distros.
+          EXCLUDE='^(ld-linux.*|libc|libm|libdl|libpthread|librt|libresolv|libutil|libnsl|libstdc\+\+|libgcc_s|libGL|libGLX|libGLdispatch|libEGL|libOpenGL|libglapi|libdrm|libgbm|libX11|libX11-xcb|libxcb|libXau|libXdmcp|libxshmfence)$'
+          ldd "$BIN" | awk '/=> \//{print $3}' | sort -u | while read -r lib; do
+            soname=$(basename "$lib")
+            base=${soname%%.so*}
+            if printf '%s\n' "$base" | grep -qE "$EXCLUDE"; then
+              echo "skip (host)  $soname"
+              continue
+            fi
+            cp -Lv "$lib" skippy-xd.AppDir/usr/lib/
+          done
+          echo "--- bundled ---"
+          ls -1 skippy-xd.AppDir/usr/lib/
+
       - name: Create AppRun
         run: |
           cat > skippy-xd.AppDir/AppRun << 'APPRUN'


### PR DESCRIPTION
## Problem

The AppDir `AppRun` exports `LD_LIBRARY_PATH=$APPDIR/usr/lib` but nothing was ever copied there. Every released AppImage silently depended on the host providing matching sonames — in particular `libjpeg.so.8` and `libgif.so.7`.

These exist on Ubuntu (the builder) and some distros but not others. On Fedora, libjpeg-turbo ships `libjpeg.so.62`, so the AppImage fails immediately:

```
error while loading shared libraries: libjpeg.so.8: cannot open shared object file: No such file or directory
```

Confirmed by a user report after the first AppImage release.

## Fix

Add a **Bundle shared libraries** CI step that `ldd`-resolves the binary's deps and copies everything into `AppDir/usr/lib`, skipping only the host-managed libraries that must never be bundled:

- glibc family (`libc`, `libm`, `libdl`, `libpthread`, `librt`, …)
- C++ runtime (`libstdc++`, `libgcc_s`)
- Core X11/GL/driver stack (`libX11`, `libxcb*`, `libGL`, `libEGL`, `libdrm`, `libgbm`, `libxshmfence`)

Everything else (libjpeg, libgif, libpng, libfreetype, libfontconfig, libXft, libXrender, libXcomposite, libXdamage, libXfixes, libXext, libXinerama, …) is copied in, making the bundle portable across distros.

## Test

Built and run on both Ubuntu and Fedora — binary launches correctly on both without any host image libs installed.