### PR TITLE
Version 0.10.7.1 (redo)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 Skippy-XD changelog
 
-0.10.7.1 -- "Bruh" (21 Jun 2026) ~/felixfung
+0.10.7.1 -- "Bruh" (24 Jun 2026) ~/felixfung
  - Layout "xd" -> "rect", "compactrect"
  - panel/reserveSpace calculation fix in multi-monitor settings
+ - Fixed pipe flushing bug on FreeBSD
 
 0.10.7 -- "Dojo Mojo" (24 May 2026) ~/felixfung
  - Highlight window with tinted border

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-v0.10.7 (2026.5.24) - 'Dojo Mojo' Edition
+v0.10.7.1 (2026.6.24) - 'Bruh' Edition


### PR DESCRIPTION
Re-releasing 0.10.7.1 as I forgot to update version.txt, and also we have now fixed a bug that allows proper running on FreeBSD.