### PR TITLE
Remove bogus code on non-daemon activation

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1387,20 +1387,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 	pid_t trigger_client = 0;
 	bool switchdesktop = false;
 
-	switch (ps->o.mode) {
-		case PROGMODE_SWITCH:
-			layout = LAYOUTMODE_SWITCH;
-		case PROGMODE_EXPOSE:
-			layout = LAYOUTMODE_EXPOSE;
-			break;
-		case PROGMODE_PAGING:
-			layout = LAYOUTMODE_PAGING;
-			break;
-		default:
-			ps->o.mode = PROGMODE_EXPOSE;
-			layout = LAYOUTMODE_EXPOSE;
-			break;
-	}
+	ps->o.mode = PROGMODE_EXPOSE;
 
 	struct pollfd r_fd[2] = {
 		{


### PR DESCRIPTION
Found in #515 by [armin-25689](https://github.com/armin-25689).

Please test with non-daemon single activation and also daemon + switch/expose/paging just in case there is any bug. Thanks!