### PR TITLE
Much improved ordering for cosmos

### DIFF
--- a/src/layout.c
+++ b/src/layout.c
@@ -225,22 +225,41 @@ set_window_center(ClientWin *window, float center_x, float center_y)
 }
 
 static void
-grid_offset(size_t rank, size_t count, size_t columns,
+grid_offset(size_t rank, size_t count, size_t columns, bool row_major,
 		float cell_width, float cell_height,
 		float *offset_x, float *offset_y)
 {
 	size_t rows = (count + columns - 1) / columns;
-	size_t column = rank / rows;
-	size_t row = rank % rows;
-	size_t column_count = count - column * rows;
 
-	if (column_count > rows)
-		column_count = rows;
+	// Scatter is column-major by default.  Row-major transposes selected
+	// incomplete grids so later Cosmos contraction reinforces columns rather
+	// than accidentally compacting them into strong horizontal rows.
+	if (row_major) {
+		size_t row = rank / columns;
+		size_t column = rank % columns;
+		size_t row_count = count - row * columns;
 
-	*offset_x = cell_width
-		* ((float) column - ((float) columns - 1.0f) / 2.0f);
-	*offset_y = cell_height
-		* ((float) row - ((float) column_count - 1.0f) / 2.0f);
+		if (row_count > columns)
+			row_count = columns;
+
+		*offset_x = cell_width
+			* ((float) column - ((float) row_count - 1.0f) / 2.0f);
+		*offset_y = cell_height
+			* ((float) row - ((float) rows - 1.0f) / 2.0f);
+	}
+	else {
+		size_t column = rank / rows;
+		size_t row = rank % rows;
+		size_t column_count = count - column * rows;
+
+		if (column_count > rows)
+			column_count = rows;
+
+		*offset_x = cell_width
+			* ((float) column - ((float) columns - 1.0f) / 2.0f);
+		*offset_y = cell_height
+			* ((float) row - ((float) column_count - 1.0f) / 2.0f);
+	}
 }
 
 static unsigned int
@@ -334,11 +353,25 @@ run_scatter(ClientWin **windows, size_t count,
 			rows = (member_count + columns - 1) / columns;
 		}
 
+		// The incomplete last column is centered independently by grid_offset().
+		// If its missing-cell count is even, it lies on the same row lattice as
+		// the full columns and contraction can make those rows visually dominant.
+		// Scatter those cases row-major instead, which transposes the ambiguity
+		// and favors emergent column structure.  A lone last-column window in a
+		// wider grid of at least four rows is the remaining staggered case seen
+		// to compact into rows (for example 17 equal maximized windows).
+		size_t partial_column = member_count - (columns - 1) * rows;
+		bool row_major = partial_column < rows
+			&& ((rows - partial_column) % 2 == 0
+				|| (partial_column == 1
+					&& columns > rows
+					&& rows >= 4));
+
 		double offset_x_sum = 0;
 		double offset_y_sum = 0;
 		for (size_t rank = 0; rank < member_count; rank++) {
 			float offset_x, offset_y;
-			grid_offset(rank, member_count, columns,
+			grid_offset(rank, member_count, columns, row_major,
 					cell_width, cell_height, &offset_x, &offset_y);
 			offset_x_sum += offset_x;
 			offset_y_sum += offset_y;
@@ -387,7 +420,7 @@ run_scatter(ClientWin **windows, size_t count,
 
 			if (component[i] == component_id) {
 				float offset_x, offset_y;
-				grid_offset(rank, member_count, columns,
+				grid_offset(rank, member_count, columns, row_major,
 						cell_width, cell_height,
 						&offset_x, &offset_y);
 				set_window_center(windows[i],

--- a/src/layout.c
+++ b/src/layout.c
@@ -230,17 +230,17 @@ grid_offset(size_t rank, size_t count, size_t columns,
 		float *offset_x, float *offset_y)
 {
 	size_t rows = (count + columns - 1) / columns;
-	size_t row = rank / columns;
-	size_t column = rank % columns;
-	size_t row_count = count - row * columns;
+	size_t column = rank / rows;
+	size_t row = rank % rows;
+	size_t column_count = count - column * rows;
 
-	if (row_count > columns)
-		row_count = columns;
+	if (column_count > rows)
+		column_count = rows;
 
 	*offset_x = cell_width
-		* ((float) column - ((float) row_count - 1.0f) / 2.0f);
+		* ((float) column - ((float) columns - 1.0f) / 2.0f);
 	*offset_y = cell_height
-		* ((float) row - ((float) rows - 1.0f) / 2.0f);
+		* ((float) row - ((float) column_count - 1.0f) / 2.0f);
 }
 
 static unsigned int

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -971,7 +971,17 @@ sort_focuslist_cosmos(dlist *list, int width, int height)
 	long cut_x = 0, cut_y = 0;
 	const float column_preference = 0.20;
 	const int focus_grain_divisor = 128;
-	long long column_allowance = 2.0 * column_preference * MIN(width, height);
+	long min_x = LONG_MAX, min_y = LONG_MAX;
+	long max_x = LONG_MIN, max_y = LONG_MIN;
+	foreach_dlist(list) {
+		ClientWin *cw = (ClientWin *) iter->data;
+		min_x = MIN(min_x, cw->x);
+		min_y = MIN(min_y, cw->y);
+		max_x = MAX(max_x, cw->x + cw->src.width);
+		max_y = MAX(max_y, cw->y + cw->src.height);
+	}
+	long long column_allowance = 2.0 * column_preference
+		* MIN(max_x - min_x, max_y - min_y);
 	long grain = MAX(1, MIN(width, height) / focus_grain_divisor);
 
 	dlist_sort(list, sort_cw_by_x, 0);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -907,6 +907,200 @@ count_and_filter_clients(MainWin *mw)
 	return;
 }
 
+static int
+sort_cw_by_x(dlist *dlist1, dlist *dlist2, void *data)
+{
+	ClientWin *cw1 = (ClientWin *) dlist1->data;
+	ClientWin *cw2 = (ClientWin *) dlist2->data;
+	long x1 = (long) cw1->x * 2 + cw1->src.width;
+	long x2 = (long) cw2->x * 2 + cw2->src.width;
+	long y1 = (long) cw1->y * 2 + cw1->src.height;
+	long y2 = (long) cw2->y * 2 + cw2->src.height;
+	if (x1 < x2)
+		return -1;
+	else if (x1 > x2)
+		return 1;
+	else if (y1 < y2)
+		return -1;
+	else if (y1 > y2)
+		return 1;
+	else if (cw1->wid_client < cw2->wid_client)
+		return -1;
+	else if (cw1->wid_client > cw2->wid_client)
+		return 1;
+	else
+		return 0;
+}
+
+static int
+sort_cw_by_y(dlist *dlist1, dlist *dlist2, void *data)
+{
+	ClientWin *cw1 = (ClientWin *) dlist1->data;
+	ClientWin *cw2 = (ClientWin *) dlist2->data;
+	long y1 = (long) cw1->y * 2 + cw1->src.height;
+	long y2 = (long) cw2->y * 2 + cw2->src.height;
+	long x1 = (long) cw1->x * 2 + cw1->src.width;
+	long x2 = (long) cw2->x * 2 + cw2->src.width;
+	if (y1 < y2)
+		return -1;
+	else if (y1 > y2)
+		return 1;
+	else if (x1 < x2)
+		return -1;
+	else if (x1 > x2)
+		return 1;
+	else if (cw1->wid_client < cw2->wid_client)
+		return -1;
+	else if (cw1->wid_client > cw2->wid_client)
+		return 1;
+	else
+		return 0;
+}
+
+static dlist *
+sort_focuslist_cosmos(dlist *list, int width, int height)
+{
+	list = dlist_first(list);
+	unsigned int len = dlist_len(list);
+	if (len < 2)
+		return list;
+
+	unsigned int split_x = 0, split_y = 0;
+	long long score_x = LLONG_MAX, score_y = LLONG_MAX;
+	int balance_x = INT_MAX, balance_y = INT_MAX;
+	long cut_x = 0, cut_y = 0;
+	const float column_preference = 0.15;
+	long long column_allowance = 2.0 * column_preference * MIN(width, height);
+
+	dlist_sort(list, sort_cw_by_x, 0);
+	for (unsigned int count = 1; count < len; count++) {
+		long left_center = 0, right_center = 0;
+		unsigned int i = 0;
+		for (dlist *iter = dlist_first(list); iter; iter = iter->next, i++) {
+			ClientWin *cw = (ClientWin *) iter->data;
+			if (i == count - 1)
+				left_center = (long) cw->x * 2 + cw->src.width;
+			else if (i == count) {
+				right_center = (long) cw->x * 2 + cw->src.width;
+				break;
+			}
+		}
+		if (left_center >= right_center)
+			continue;
+		for (int candidate = -1; candidate < (int)len * 2; candidate++) {
+			long cut;
+			if (candidate < 0)
+				cut = (left_center + right_center) / 2;
+			else {
+				dlist *iter = dlist_first(list);
+				for (int j = 0; iter && j < candidate / 2; j++)
+					iter = iter->next;
+				if (!iter)
+					continue;
+				ClientWin *cw = (ClientWin *) iter->data;
+				cut = candidate % 2
+					? (long)(cw->x + cw->src.width) * 2
+					: (long)cw->x * 2;
+			}
+			if (cut <= left_center || cut >= right_center)
+				continue;
+			long long current_score = 0;
+			for (dlist *iter = dlist_first(list); iter; iter = iter->next) {
+				ClientWin *cw = (ClientWin *) iter->data;
+				long x1 = (long) cw->x * 2;
+				long x2 = (long)(cw->x + cw->src.width) * 2;
+				if (x1 < cut && cut < x2)
+					current_score += MIN(cut - x1, x2 - cut);
+			}
+			int current_balance = abs((int)len - (int)(count * 2));
+			if (score_x == LLONG_MAX
+					|| current_score < score_x
+					|| (current_score == score_x && current_balance < balance_x)) {
+				split_x = count;
+				score_x = current_score;
+				balance_x = current_balance;
+				cut_x = cut;
+			}
+		}
+	}
+
+	dlist_sort(list, sort_cw_by_y, 0);
+	for (unsigned int count = 1; count < len; count++) {
+		long top_center = 0, bottom_center = 0;
+		unsigned int i = 0;
+		for (dlist *iter = dlist_first(list); iter; iter = iter->next, i++) {
+			ClientWin *cw = (ClientWin *) iter->data;
+			if (i == count - 1)
+				top_center = (long) cw->y * 2 + cw->src.height;
+			else if (i == count) {
+				bottom_center = (long) cw->y * 2 + cw->src.height;
+				break;
+			}
+		}
+		if (top_center >= bottom_center)
+			continue;
+		for (int candidate = -1; candidate < (int)len * 2; candidate++) {
+			long cut;
+			if (candidate < 0)
+				cut = (top_center + bottom_center) / 2;
+			else {
+				dlist *iter = dlist_first(list);
+				for (int j = 0; iter && j < candidate / 2; j++)
+					iter = iter->next;
+				if (!iter)
+					continue;
+				ClientWin *cw = (ClientWin *) iter->data;
+				cut = candidate % 2
+					? (long)(cw->y + cw->src.height) * 2
+					: (long)cw->y * 2;
+			}
+			if (cut <= top_center || cut >= bottom_center)
+				continue;
+			long long current_score = 0;
+			for (dlist *iter = dlist_first(list); iter; iter = iter->next) {
+				ClientWin *cw = (ClientWin *) iter->data;
+				long y1 = (long) cw->y * 2;
+				long y2 = (long)(cw->y + cw->src.height) * 2;
+				if (y1 < cut && cut < y2)
+					current_score += MIN(cut - y1, y2 - cut);
+			}
+			int current_balance = abs((int)len - (int)(count * 2));
+			if (score_y == LLONG_MAX
+					|| current_score < score_y
+					|| (current_score == score_y && current_balance < balance_y)) {
+				split_y = count;
+				score_y = current_score;
+				balance_y = current_balance;
+				cut_y = cut;
+			}
+		}
+	}
+
+	if (!split_x && !split_y) {
+		printfdf(false, "(): cosmos focus fallback column sort n=%u", len);
+		dlist_sort(list, sort_cw_by_column, 0);
+		return dlist_first(list);
+	}
+
+	if (split_x && (!split_y || score_x <= score_y + column_allowance)) {
+		printfdf(false, "(): cosmos focus vertical n=%u split=%u cut2=%ld score=%lld balance=%d",
+				len, split_x, cut_x, score_x, balance_x);
+		dlist_sort(list, sort_cw_by_x, 0);
+		dlist *second = dlist_split_nth(list, split_x);
+		list = sort_focuslist_cosmos(list, width, height);
+		second = sort_focuslist_cosmos(second, width, height);
+		return dlist_join(list, second);
+	}
+
+	printfdf(false, "(): cosmos focus horizontal n=%u split=%u cut2=%ld score=%lld balance=%d",
+			len, split_y, cut_y, score_y, balance_y);
+	dlist_sort(list, sort_cw_by_y, 0);
+	dlist *second = dlist_split_nth(list, split_y);
+	list = sort_focuslist_cosmos(list, width, height);
+	second = sort_focuslist_cosmos(second, width, height);
+	return dlist_join(list, second);
+}
+
 static void
 init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 	session_t *ps = mw->ps;
@@ -915,8 +1109,13 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 	// is important for prev/next window selection
 	mw->focuslist = dlist_dup(mw->clientondesktop);
 
-	if (layout == LAYOUTMODE_EXPOSE && ps->o.exposeLayout != LAYOUT_XD)
-		dlist_sort(mw->focuslist, sort_cw_by_column, 0);
+	if ((ps->o.mode == PROGMODE_EXPOSE
+	  && ps->o.exposeLayout == LAYOUT_COSMOS)
+	 || (ps->o.mode == PROGMODE_SWITCH
+	  && ps->o.switchLayout == LAYOUT_COSMOS))
+		mw->focuslist = sort_focuslist_cosmos(mw->focuslist,
+				(int)(mw->width / mw->multiplier),
+				(int)(mw->height / mw->multiplier));
 	else
 		dlist_reverse(mw->focuslist);
 
@@ -950,9 +1149,6 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 			XFlush(ps->dpy);
 		}
 	}
-
-	if (layout == LAYOUTMODE_SWITCH && ps->o.switchLayout == LAYOUT_COSMOS)
-		dlist_sort(mw->focuslist, sort_cw_by_column, 0);
 }
 
 static void

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1109,10 +1109,8 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 	// is important for prev/next window selection
 	mw->focuslist = dlist_dup(mw->clientondesktop);
 
-	if ((ps->o.mode == PROGMODE_EXPOSE
+	if (ps->o.mode == PROGMODE_EXPOSE
 	  && ps->o.exposeLayout == LAYOUT_COSMOS)
-	 || (ps->o.mode == PROGMODE_SWITCH
-	  && ps->o.switchLayout == LAYOUT_COSMOS))
 		mw->focuslist = sort_focuslist_cosmos(mw->focuslist,
 				(int)(mw->width / mw->multiplier),
 				(int)(mw->height / mw->multiplier));
@@ -1149,6 +1147,12 @@ init_focus(MainWin *mw, enum layoutmode layout, Window leader) {
 			XFlush(ps->dpy);
 		}
 	}
+
+	if (ps->o.mode == PROGMODE_SWITCH
+	  && ps->o.switchLayout == LAYOUT_COSMOS)
+		mw->focuslist = sort_focuslist_cosmos(mw->focuslist,
+				(int)(mw->width / mw->multiplier),
+				(int)(mw->height / mw->multiplier));
 }
 
 static void

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1078,7 +1078,7 @@ sort_focuslist_cosmos(dlist *list, int width, int height)
 
 	if (!split_x && !split_y) {
 		printfdf(false, "(): cosmos focus fallback column sort n=%u", len);
-		dlist_sort(list, sort_cw_by_column, 0);
+		dlist_sort(list, sort_cw_by_x, 0);
 		return dlist_first(list);
 	}
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -969,8 +969,10 @@ sort_focuslist_cosmos(dlist *list, int width, int height)
 	long long score_x = LLONG_MAX, score_y = LLONG_MAX;
 	int balance_x = INT_MAX, balance_y = INT_MAX;
 	long cut_x = 0, cut_y = 0;
-	const float column_preference = 0.15;
+	const float column_preference = 0.20;
+	const int focus_grain_divisor = 128;
 	long long column_allowance = 2.0 * column_preference * MIN(width, height);
+	long grain = MAX(1, MIN(width, height) / focus_grain_divisor);
 
 	dlist_sort(list, sort_cw_by_x, 0);
 	for (unsigned int count = 1; count < len; count++) {
@@ -985,7 +987,7 @@ sort_focuslist_cosmos(dlist *list, int width, int height)
 				break;
 			}
 		}
-		if (left_center >= right_center)
+		if (right_center - left_center <= grain * 2)
 			continue;
 		for (int candidate = -1; candidate < (int)len * 2; candidate++) {
 			long cut;
@@ -1037,7 +1039,7 @@ sort_focuslist_cosmos(dlist *list, int width, int height)
 				break;
 			}
 		}
-		if (top_center >= bottom_center)
+		if (bottom_center - top_center <= grain * 2)
 			continue;
 		for (int candidate = -1; candidate < (int)len * 2; candidate++) {
 			long cut;

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -1393,31 +1393,6 @@ sort_cw_by_row(dlist* dlist1, dlist* dlist2, void* data)
 }
 
 static inline int
-sort_cw_by_column(dlist* dlist1, dlist* dlist2, void* data)
-{
-	ClientWin *cw1 = (ClientWin *) dlist1->data;
-	ClientWin *cw2 = (ClientWin *) dlist2->data;
-
-	int tilewidth = MIN(cw1->src.width, cw2->src.width);
-	int tileheight = MIN(cw1->src.height, cw2->src.height);
-
-	int cw1x = cw1->x / tilewidth,
-		cw1y = cw1->y / tileheight,
-		cw2x = cw2->x / tilewidth,
-		cw2y = cw2->y / tileheight;
-
-	if (cw1y < cw2y)
-		return -1;
-	else if (cw2y < cw1y)
-		return 1;
-	else if (cw1x < cw2x)
-		return -1;
-	else if (cw2x < cw1x)
-		return 1;
-	return 0;
-}
-
-static inline int
 sort_cw_by_id(dlist* dlist1, dlist* dlist2, void* data)
 {
 	ClientWin *cw1 = (ClientWin *) dlist1->data;


### PR DESCRIPTION
Current cosmos ordering (used for next/prev, default with n/p keys, also if you use cosmos layout for switch) is based on simple x/y coordinates sorting Often this is imperfect, leading to non-intuitive navigation.

New ordering intuition:
- ~~Column based. As most windows are wide, often windows naturally form columns, and column navigation is most intuitive.~~ (after much experimentation row based is natural and superior)
- Global knowledge of layout is important, see examples in #216.

The solution here is to recursivelly divide a layout by bisecting horizontally/vertically until each slice has only one window left. The slices are chosen/ranked by how little of windows will be sliced off, with preference given to horizontal slices.

All examples in #216 and many more complex cases I tried works well.